### PR TITLE
perf(build): remove context from default derivation

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,7 +3,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: fluidattacks/makes@main
+    - uses: ./
       name: formatBash
       with:
         args: m /formatBash
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: fluidattacks/makes@main
+    - uses: ./
       name: formatPython
       with:
         args: m /formatPython
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: fluidattacks/makes@main
+    - uses: ./
       name: helloWorld
       with:
         args: m /helloWorld

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,7 +6,7 @@ jobs:
     - uses: fluidattacks/makes@main
       name: formatBash
       with:
-        args: m .formatBash
+        args: m /formatBash
   formatPython:
     runs-on: ubuntu-latest
     steps:
@@ -14,7 +14,7 @@ jobs:
     - uses: fluidattacks/makes@main
       name: formatPython
       with:
-        args: m .formatPython
+        args: m /formatPython
   helloWorld:
     runs-on: ubuntu-latest
     steps:
@@ -22,7 +22,7 @@ jobs:
     - uses: fluidattacks/makes@main
       name: helloWorld
       with:
-        args: m .helloWorld
+        args: m /helloWorld
 name: Makes
 on:
   pull_request:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -8,7 +8,7 @@ jobs:
         GITHUB_ACTOR: ${{ secrets._GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
       with:
-        args: m .deployContainerImage.makesGitHub
+        args: m /deployContainerImage/makesGitHub
   deployContainerImage_makesGitHubMonthly:
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +18,7 @@ jobs:
         GITHUB_ACTOR: ${{ secrets._GITHUB_USER }}
         GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
       with:
-        args: m .deployContainerImage.makesGitHubMonthly
+        args: m /deployContainerImage/makesGitHubMonthly
   deployContainerImage_makesGitLab:
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +29,7 @@ jobs:
         CI_REGISTRY_PASSWORD: ${{ secrets.GITLAB_TOKEN }}
         CI_REGISTRY_USER: ${{ secrets.GITLAB_USER }}
       with:
-        args: m .deployContainerImage.makesGitLab
+        args: m /deployContainerImage/makesGitLab
   deployContainerImage_makesGitLabMonthly:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +40,7 @@ jobs:
         CI_REGISTRY_PASSWORD: ${{ secrets.GITLAB_TOKEN }}
         CI_REGISTRY_USER: ${{ secrets.GITLAB_USER }}
       with:
-        args: m .deployContainerImage.makesGitLabMonthly
+        args: m /deployContainerImage/makesGitLabMonthly
 name: Makes
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Makes v21.08-pre2
+# Makes v21.08-pre3
 
 A SecDevOps framework
 powered by [Nix][NIX].
@@ -142,10 +142,10 @@ In order to use Makes you'll need to:
     `$ nix-env -if https://fluidattacks.com/makes/install`
 
     [Other releases][MAKES_RELEASES]:
-    `$ nix-env -if https://fluidattacks.com/makes/install/21.08-pre2`
+    `$ nix-env -if https://fluidattacks.com/makes/install/21.08-pre3`
 
     We will install two commands in your system:
-    `m`, and `m-v21.08-pre2` (depending on the version you installed).
+    `m`, and `m-v21.08-pre3` (depending on the version you installed).
 
 Makes targets two kind of users:
 - Final users: People that want to use projects built with Makes.
@@ -364,15 +364,15 @@ Ensure that the Makes version people use in your project is the one you want.
 This increases reproducibility and prevents compatibility mismatches.
 People will use the Makes version you know your project works with.
 
-Type:
-- (`enum [ "21.08-pre2" ]`): Optional.
+Attributes:
+- self (`enum [ "21.08-pre3" ]`): Optional.
   Defaults to the version installed in the system.
 
 Example `makes.nix`:
 
 ```nix
 {
-  requiredMakesVersion = "21.08-pre2";
+  requiredMakesVersion = "21.08-pre3";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ Makes targets two kind of users:
 
       ```
       Outputs list for project: ./
-        .helloWorld
+        /helloWorld
       ```
 
-    - Run a command: `$ m .helloWorld 1 2 3`
+    - Run a command: `$ m /helloWorld 1 2 3`
 
       ```
       [INFO] Hello from Makes! Jane Doe.
@@ -202,10 +202,10 @@ Makes targets two kind of users:
 
       ```
       Outputs list for project: ./
-        .helloWorld
+        /helloWorld
       ```
 
-    - Run a command: `$ m .helloWorld 1 2 3`
+    - Run a command: `$ m /helloWorld 1 2 3`
 
       ```
       [INFO] Hello from Makes! Jane Doe.
@@ -261,7 +261,7 @@ jobs:
       env:
         SECRET_NAME: ${{ secrets.SECRET_IN_YOUR_GITHUB }}
       with:
-        args: m .helloWorld 1 2 3
+        args: m /helloWorld 1 2 3
 ```
 
 ## Configuring on GitLab CI/CD
@@ -281,7 +281,7 @@ helloWorld:
   #   yy.mm: monthly release (example: /makes:21.07)
   image: registry.gitlab.com/fluidattacks/product/makes:main
   script:
-    - m .helloWorld 1 2 3
+    - m /helloWorld 1 2 3
 ```
 
 Secrets can be propagated to Makes through [GitLab Variables][GITLAB_VARS],
@@ -324,7 +324,7 @@ Example `makes.nix`:
 }
 ```
 
-Example invocation: `$ m .formatBash`
+Example invocation: `$ m /formatBash`
 
 ### formatPython
 
@@ -354,7 +354,7 @@ Example `makes.nix`:
 }
 ```
 
-Example invocation: `$ m .formatPython`
+Example invocation: `$ m /formatPython`
 
 ## Pinning
 
@@ -429,7 +429,7 @@ Example `makes.nix`:
         tag = "fluidattacks/redis:$(date +%Y.%m)"; # Tag from command
       };
       makesGitLab = {
-        src = config.outputs."container-image";
+        src = config.outputs."/containerImage";
         registry = "registry.gitlab.com";
         tag = "fluidattacks/product/makes:$MY_VAR"; # Tag from env var
       };
@@ -437,11 +437,11 @@ Example `makes.nix`:
   };
 ```
 
-Example invocation: `$ DOCKER_HUB_USER=user DOCKER_HUB_PASS=123 m .deployContainerImage.nginxDockerHub`
+Example invocation: `$ DOCKER_HUB_USER=user DOCKER_HUB_PASS=123 m /deployContainerImage/nginxDockerHub`
 
-Example invocation: `$ GITHUB_ACTOR=user GITHUB_TOKEN=123 m .deployContainerImage.makesGitHub`
+Example invocation: `$ GITHUB_ACTOR=user GITHUB_TOKEN=123 m /deployContainerImage/makesGitHub`
 
-Example invocation: `$ CI_REGISTRY_USER=user CI_REGISTRY_PASSWORD=123 m .deployContainerImage.makesGitLab`
+Example invocation: `$ CI_REGISTRY_USER=user CI_REGISTRY_PASSWORD=123 m /deployContainerImage/makesGitLab`
 
 ## Examples
 
@@ -466,7 +466,7 @@ Example `makes.nix`:
 }
 ```
 
-Example invocation: `$ m .helloWorld 1 2 3`
+Example invocation: `$ m /helloWorld 1 2 3`
 
 # Extending Makes
 
@@ -508,10 +508,10 @@ In order to do this:
 
       ```
       Outputs list for project: ./
-        .example
+        /example
       ```
 
-    - Run the command: `$ m .example`
+    - Run the command: `$ m /example`
 
       ```
       Hello from Makes!
@@ -525,9 +525,9 @@ Output names will me mapped in an intuitive way:
 
 | `main.nix` position                                | Output name       | Invocation command   |
 |----------------------------------------------------|-------------------|----------------------|
-| `/path/to/my/project/makes/main.nix`               | `""`              | `$ m .`              |
-| `/path/to/my/project/makes/example/main.nix`       | `"example"`       | `$ m .example`       |
-| `/path/to/my/project/makes/other/example/main.nix` | `"other.example"` | `$ m .other.example` |
+| `/path/to/my/project/makes/main.nix`               | `"/"`              | `$ m /`              |
+| `/path/to/my/project/makes/example/main.nix`       | `"/example"`       | `$ m /example`       |
+| `/path/to/my/project/makes/other/example/main.nix` | `"/other/example"` | `$ m /other/example` |
 
 ## Main.nix format
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,5 +13,5 @@ runs:
     - bash
     - -c
     - set -x && ${INPUT_ARGS}
-  image: docker://ghcr.io/fluidattacks/makes:21.08-pre2
+  image: docker://ghcr.io/fluidattacks/makes:21.08-pre3
   using: docker

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
 (import ./src/evaluator.nix {
   head = ./.;
   makesVersion = "21.08-pre2";
-}).config.outputs.""
+}).config.outputs."/"

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
 (import ./src/evaluator.nix {
   head = ./.;
-  makesVersion = "21.08-pre2";
+  makesVersion = "21.08-pre3";
 }).config.outputs."/"

--- a/makes.nix
+++ b/makes.nix
@@ -6,22 +6,22 @@
     enable = true;
     images = {
       makesGitHub = {
-        src = config.outputs."container-image";
+        src = config.outputs."/container-image";
         registry = "ghcr.io";
         tag = "fluidattacks/makes:main";
       };
       makesGitHubMonthly = {
-        src = config.outputs."container-image";
+        src = config.outputs."/container-image";
         registry = "ghcr.io";
         tag = "fluidattacks/makes:${config.requiredMakesVersion}";
       };
       makesGitLab = {
-        src = config.outputs."container-image";
+        src = config.outputs."/container-image";
         registry = "registry.gitlab.com";
         tag = "fluidattacks/product/makes:main";
       };
       makesGitLabMonthly = {
-        src = config.outputs."container-image";
+        src = config.outputs."/container-image";
         registry = "registry.gitlab.com";
         tag = "fluidattacks/product/makes:${config.requiredMakesVersion}";
       };

--- a/makes.nix
+++ b/makes.nix
@@ -39,5 +39,5 @@
     enable = true;
     name = "Jane Doe";
   };
-  requiredMakesVersion = "21.08-pre2";
+  requiredMakesVersion = "21.08-pre3";
 }

--- a/makes/container-image/main.nix
+++ b/makes/container-image/main.nix
@@ -57,6 +57,6 @@ makeContainerImage {
     inputs.makesPackages.nixpkgs.gzip
     inputs.makesPackages.nixpkgs.nix
 
-    outputs.""
+    outputs."/"
   ];
 }

--- a/src/cli.py
+++ b/src/cli.py
@@ -72,7 +72,7 @@ def _get_attrs(head: str) -> List[str]:
     )
     if code == 0:
         with open(out) as file:
-            return [f".{attr}" for attr in json.load(file)]
+            return json.load(file)
 
     raise Error(f"Unable to list project outputs from: {FROM}")
 
@@ -124,11 +124,11 @@ def cli(args: List[str]) -> None:
         _help_and_exit(attrs)
 
     cwd: str = getcwd()
-    out: str = join(cwd, f"result{attr}")
+    out: str = join(cwd, f"result{attr.replace('/', '-')}")
     actions_path: str = join(out, "makes-actions.json")
 
     code, _, _ = _run(
-        args=_nix_build(head, f'config.outputs."{attr[1:]}"', out),
+        args=_nix_build(head, f'config.outputs."{attr}"', out),
     )
 
     if code == 0:

--- a/src/modules/outputs/builtins/deploy-container-image/default.nix
+++ b/src/modules/outputs/builtins/deploy-container-image/default.nix
@@ -38,7 +38,7 @@
     outputs = lib.mkIf config.deployContainerImage.enable
       (lib.attrsets.mapAttrs'
         (name: { src, registry, tag }: {
-          name = "deployContainerImage.${name}";
+          name = "/deployContainerImage/${name}";
           value = deployContainerImage {
             containerImage = src;
             inherit name;

--- a/src/modules/outputs/builtins/format-bash/default.nix
+++ b/src/modules/outputs/builtins/format-bash/default.nix
@@ -22,7 +22,7 @@
   };
   config = {
     outputs = {
-      formatBash = lib.mkIf config.formatBash.enable (makeScript {
+      "/formatBash" = lib.mkIf config.formatBash.enable (makeScript {
         arguments = {
           envTargets = builtinLambdas.asBashArray
             (builtins.map

--- a/src/modules/outputs/builtins/format-python/default.nix
+++ b/src/modules/outputs/builtins/format-python/default.nix
@@ -22,7 +22,7 @@
   };
   config = {
     outputs = {
-      formatPython = lib.mkIf config.formatPython.enable (makeScript {
+      "/formatPython" = lib.mkIf config.formatPython.enable (makeScript {
         arguments = {
           envSettingsBlack = ./settings-black.toml;
           envSettingsIsort = ./settings-isort.toml;

--- a/src/modules/outputs/builtins/hello-world/default.nix
+++ b/src/modules/outputs/builtins/hello-world/default.nix
@@ -19,7 +19,7 @@
   };
   config = {
     outputs = {
-      helloWorld = lib.mkIf config.helloWorld.enable (makeScript {
+      "/helloWorld" = lib.mkIf config.helloWorld.enable (makeScript {
         name = "hello-world";
         entrypoint = ''
           info Hello from Makes! ${config.helloWorld.name}.

--- a/src/modules/outputs/builtins/lint-bash/default.nix
+++ b/src/modules/outputs/builtins/lint-bash/default.nix
@@ -22,7 +22,7 @@
   };
   config = {
     outputs = {
-      lintBash = lib.mkIf config.lintBash.enable (makeScript {
+      "/lintBash" = lib.mkIf config.lintBash.enable (makeScript {
         arguments = {
           envTargets = builtinLambdas.asBashArray
             (builtins.map

--- a/src/modules/outputs/custom.nix
+++ b/src/modules/outputs/custom.nix
@@ -16,7 +16,7 @@ let
             then attrsFromPath "${path}/${name}" (position ++ [ name ])
             else if name == "main.nix"
             then {
-              "${builtins.concatStringsSep "." position}" =
+              "/${builtins.concatStringsSep "/" position}" =
                 (import "${path}/main.nix" args);
             }
             else { })

--- a/src/modules/required-makes-version.nix
+++ b/src/modules/required-makes-version.nix
@@ -7,7 +7,7 @@
 }:
 let
   versions = [
-    "21.08-pre2"
+    "21.08-pre3"
   ];
 in
 {


### PR DESCRIPTION
- Previously when buildint makes/main.nix
  we used outputs."" which due to some
  nix internals carry out the context of
  all the outputs
- Now building makes/main.nix just builds
  outputs."/" which prevents loading all
  outputs