### PR TITLE
feat(cross): ephemeral head

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,16 +166,25 @@ Makes targets two kind of users:
 
 ## Getting started as user
 
-1.  Download the Makes project of your choice.
+1.  For local [Makes][MAKES] projects:
 
-1.  `$ cd /path/to/a/project`
+    1.  `$ cd /path/to/a/makes/project`
+
+    For remote [Makes][MAKES] projects:
+
+    1.  Export `M_FROM` to the git-clone URL of the project:
+
+        For example:
+
+        - http: `$ export M_FROM=https://github.com/fluidattacks/makes`
+        - ssh: `$ export M_FROM=git@github.com:fluidattacks/makes`
 
 1.  Now run makes!
 
     - List all available commands: `$ m`
 
       ```
-      Outputs list for project: ./
+      Outputs list for project: https://github.com/fluidattacks/makes
         /helloWorld
       ```
 
@@ -214,7 +223,7 @@ Makes targets two kind of users:
     - List all available commands: `$ m`
 
       ```
-      Outputs list for project: ./
+      Outputs list for project: /path/to/my/project
         /helloWorld
       ```
 
@@ -693,7 +702,7 @@ In order to do this:
     - List all available commands: `$ m`
 
       ```
-      Outputs list for project: ./
+      Outputs list for project: /path/to/my/project
         /example
       ```
 

--- a/makes/main.nix
+++ b/makes/main.nix
@@ -16,7 +16,7 @@ makeScript {
   };
   entrypoint = ''
     _EVALUATOR=__envSrc__/evaluator.nix \
-    _MAKES_VERSION=${config.requiredMakesVersion} \
+    _M_VERSION=${config.requiredMakesVersion} \
     _NIX_BUILD=__envNix__/bin/nix-build \
     _NIX_INSTANTIATE=__envNix__/bin/nix-instantiate \
     python -m cli "$@"


### PR DESCRIPTION
- Working over the git repository, with
  tainted files and spurious outputs creates
  irreproducibility
- Makes now will clone the HEAD of the repo
  into an ephemeral folder
- This also introduces a cool side effect
  of being able to run makes over remote
  repositories by using M_FROM=repo m