### PR TITLE
perf(build): #29 cache hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,11 +465,18 @@ Attributes:
 
 Custom Types:
 - dirOfModulesType (`submodule`):
+  - extraSources (`listOf package`): Optional.
+    List of scripts that will be source before performing the linting process.
+    Can be used to setup dependencies of the project in the environment.
+    Defaults to `[ ]`
   - python (`enum [ "3.7" "3.8" "3.9" ]`):
     Python interpreter version that your package/module is designed for.
   - src (`str`):
     Path to the folder that contains inside many packages/modules.
 - moduleType (`submodule`):
+  - extraSources (`listOf package`): Optional.
+    List of scripts that will be source before performing the linting process.
+    Can be used to setup dependencies of the project in the environment.
   - python (`enum [ "3.7" "3.8" "3.9" ]`):
     Python interpreter version that your package/module is designed for.
   - src (`str`):

--- a/src/modules/outputs/builtins/lint-python/default.nix
+++ b/src/modules/outputs/builtins/lint-python/default.nix
@@ -9,7 +9,7 @@
 , ...
 }:
 let
-  makeModule = name: { python, src }: {
+  makeModule = name: { extraSources, python, src }: {
     name = "/lintPython/module/${name}";
     value = makeDerivation {
       arguments = {
@@ -22,7 +22,7 @@ let
         envPaths = [
           inputs.makesPackages.nixpkgs.findutils
         ];
-        envSources = [
+        envSources = extraSources ++ [
           (makePythonEnvironment {
             dependencies = [
               "mypy==0.910"
@@ -64,13 +64,14 @@ let
       builder = ./builder-module.sh;
     };
   };
-  makeDirOfModules = name: { python, src }:
+  makeDirOfModules = name: { extraSources, python, src }:
     let
       moduleNames = builtins.attrNames (builtins.readDir (path src));
       modules = builtins.map
         (moduleName: {
           name = "/lintPython/dirOfModules/${name}/${moduleName}";
           value = (makeModule moduleName {
+            inherit extraSources;
             inherit python;
             src = "${src}/${moduleName}";
           }).value;
@@ -99,6 +100,10 @@ in
         default = { };
         type = lib.types.attrsOf (lib.types.submodule (_: {
           options = {
+            extraSources = lib.mkOption {
+              default = [ ];
+              type = lib.types.listOf lib.types.package;
+            };
             python = lib.mkOption {
               type = lib.types.enum [ "3.7" "3.8" "3.9" ];
             };
@@ -112,6 +117,10 @@ in
         default = { };
         type = lib.types.attrsOf (lib.types.submodule (_: {
           options = {
+            extraSources = lib.mkOption {
+              default = [ ];
+              type = lib.types.listOf lib.types.package;
+            };
             python = lib.mkOption {
               type = lib.types.enum [ "3.7" "3.8" "3.9" ];
             };

--- a/src/modules/outputs/builtins/lint-python/default.nix
+++ b/src/modules/outputs/builtins/lint-python/default.nix
@@ -29,7 +29,7 @@ let
               "prospector==1.3.1"
               "returns==0.16.0"
             ];
-            name = "lint-python-for-${name}";
+            name = "lint-python";
             inherit python;
             subDependencies = [
               "astroid==2.4.1"


### PR DESCRIPTION
- By making this name constant the dependencies
  are shared in all generated lint scripts