### PR TITLE
feat(build): #171 add fetchers

### DIFF
--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -1,0 +1,29 @@
+{ config
+, head
+, lib
+}:
+let args = {
+  inherit config;
+  builtinLambdas = import ./builtin/lambdas.nix args;
+  builtinShellCommands = ./builtin/shell-commands.sh;
+  builtinShellOptions = ./builtin/shell-options.sh;
+  deployContainerImage = import ./deploy-container-image args;
+  fakeSha256 = lib.fakeSha256;
+  fakeSha512 = lib.fakeSha512;
+  fetchNixpkgs = import ./fetchers/nixpkgs.nix args;
+  fetchUrl = import ./fetchers/url.nix args;
+  fetchZip = import ./fetchers/zip.nix args;
+  inputs = config.inputs;
+  inherit lib;
+  makeContainerImage = import ./make-container-image args;
+  makeDerivation = import ./make-derivation args;
+  makeNodeEnvironment = import ./make-node-environment args;
+  makeParallel = import ./make-parallel args;
+  makePythonEnvironment = import ./make-python-environment args;
+  makeScript = import ./make-script args;
+  makeSearchPaths = import ./make-search-paths args;
+  makeTemplate = import ./make-template args;
+  outputs = config.outputs;
+  path = path: head + path;
+};
+in args

--- a/src/args/fetchers/nixpkgs.nix
+++ b/src/args/fetchers/nixpkgs.nix
@@ -1,0 +1,23 @@
+{ fetchUrl
+, ...
+}:
+{ rev
+, sha256 ? fakeSha256
+, acceptAndroidSdkLicense ? true
+, overlays ? [ ]
+}:
+let
+  src = fetchUrl {
+    inherit sha256;
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.zip";
+  };
+in
+import src {
+  config = {
+    allowUnfree = true;
+    android_sdk = {
+      accept_license = acceptAndroidSdkLicense;
+    };
+  };
+  inherit overlays;
+}

--- a/src/args/fetchers/url.nix
+++ b/src/args/fetchers/url.nix
@@ -1,0 +1,10 @@
+{ inputs
+, ...
+}:
+{ url
+, sha256 ? fakeSha256
+}:
+inputs.makesPackages.nixpkgs.fetchurl {
+  inherit sha256;
+  inherit url;
+}

--- a/src/args/fetchers/zip.nix
+++ b/src/args/fetchers/zip.nix
@@ -1,0 +1,10 @@
+{ inputs
+, ...
+}:
+{ url
+, sha256 ? fakeSha256
+}:
+inputs.makesPackages.nixpkgs.fetchzip {
+  inherit sha256;
+  inherit url;
+}

--- a/src/modules/outputs/default.nix
+++ b/src/modules/outputs/default.nix
@@ -3,27 +3,8 @@
 , lib
 , ...
 }:
-let args = {
-  inherit config;
-  inherit lib;
-  builtinLambdas = import ../../args/builtin/lambdas.nix args;
-  builtinShellCommands = ../../args/builtin/shell-commands.sh;
-  builtinShellOptions = ../../args/builtin/shell-options.sh;
-  deployContainerImage = import ../../args/deploy-container-image args;
-  fakeSha256 = lib.fakeSha256;
-  fakeSha512 = lib.fakeSha512;
-  inputs = config.inputs;
-  makeContainerImage = import ../../args/make-container-image args;
-  makeDerivation = import ../../args/make-derivation args;
-  makeNodeEnvironment = import ../../args/make-node-environment args;
-  makeParallel = import ../../args/make-parallel args;
-  makePythonEnvironment = import ../../args/make-python-environment args;
-  makeScript = import ../../args/make-script args;
-  makeSearchPaths = import ../../args/make-search-paths args;
-  makeTemplate = import ../../args/make-template args;
-  outputs = config.outputs;
-  path = path: head + path;
-};
+let
+  args = import ../../args { inherit head config lib; };
 in
 {
   imports = [


### PR DESCRIPTION
- They do not require sha256 by default, but
  obviously they will fail because the hash
  does not coincide and thus still force
  pinning dependencies. But it is way
  more confortable this way