### PR TITLE
feat(cross): #36 make search paths purity

### DIFF
--- a/README.md
+++ b/README.md
@@ -943,7 +943,8 @@ programs find other programs,
 dependencies, libraries, etc,
 through special environment variables.
 
-Below we describe shortly the purpose of the environment variables we currently support.
+Below we describe shortly the purpose
+of the environment variables we currently support.
 
 - [CLASSPATH][CLASSPATH]:
   Location of user-defined classes and packages.
@@ -962,6 +963,20 @@ Below we describe shortly the purpose of the environment variables we currently 
 
 - [PYTHONPATH][PYTHONPATH]:
   Location of [Python][PYTHON] modules and site-packages.
+
+`makeSearchPaths` helps you write code like this:
+
+```nix
+makeSearchPaths {
+  bin = [ inputs.nixpkgs.git ];
+}
+```
+
+Instead of this:
+
+```bash
+export PATH="/nix/store/m5kp2jhiga25ynk3iq61f4psaqixg7ib-git-2.32.0/bin${PATH:+:}${PATH:-}"
+```
 
 Inputs:
 

--- a/makes/nested/main.nix
+++ b/makes/nested/main.nix
@@ -1,10 +1,9 @@
-{ makeTemplate
+{ inputs
+, makeSearchPaths
 , ...
 }:
-makeTemplate {
-  arguments = {
-    envVar = "123";
-  };
-  name = "test";
-  template = "__envVar__";
+makeSearchPaths {
+  bin = [
+    inputs.nixpkgs.git
+  ];
 }

--- a/src/args/make-search-paths/default.nix
+++ b/src/args/make-search-paths/default.nix
@@ -5,7 +5,7 @@
 
 let
   export = envVar: envPath: envDrv:
-    "export ${envVar}=\"${envDrv}${envPath}:\${${envVar}:-}\"";
+    "export ${envVar}=\"${envDrv}${envPath}\${${envVar}:+:}\${${envVar}:-}\"";
   sourceDrv = envDrv:
     "source ${envDrv}";
 in


### PR DESCRIPTION
- Make it not append an empty search path at the
  end because it can be interpreted as the current
  working directory (accidental impurity)
- Document with an example