### PR TITLE
fix(build): #232 use ephemeral token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
       with:
         tag_name: 21.08
       env:
-        GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
     - uses: johnwbyrd/update-release@v1.0.0
       with:
         files: README.md


### PR DESCRIPTION
- Use the ephemeral github token as the secret no
  longer exists