### PR TITLE
feat(build): #252 aws secrets from env

### DIFF
--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -31,6 +31,7 @@ let
     makeScript = import ./make-script/default.nix args;
     makeScriptParallel = import ./make-script-parallel/default.nix args;
     makeSearchPaths = import ./make-search-paths/default.nix args;
+    makeSecretAwsFromEnv = import ./make-secret-aws-from-env/default.nix args;
     makeTerraformEnvironment = import ./make-terraform-environment/default.nix args;
     inherit makesVersion;
     makeTemplate = import ./make-template/default.nix args;

--- a/src/args/lint-terraform/default.nix
+++ b/src/args/lint-terraform/default.nix
@@ -3,7 +3,8 @@
 , makeTerraformEnvironment
 , ...
 }:
-{ config
+{ authentication
+, config
 , name
 , version
 , src
@@ -24,6 +25,6 @@ makeScript {
       (makeTerraformEnvironment {
         inherit version;
       })
-    ];
+    ] ++ authentication;
   };
 }

--- a/src/args/make-secret-aws-from-env/default.nix
+++ b/src/args/make-secret-aws-from-env/default.nix
@@ -1,0 +1,19 @@
+{ makeTemplate
+, ...
+}:
+{ accessKeyId
+, defaultRegion
+, name
+, secretAccessKey
+, sessionToken
+}:
+makeTemplate {
+  replace = {
+    __argAccessKeyId__ = accessKeyId;
+    __argDefaultRegion__ = defaultRegion;
+    __argSecretAcessKey__ = secretAccessKey;
+    __argSessionToken__ = sessionToken;
+  };
+  name = "make-secret-aws-from-env-for-${name}";
+  template = ./template.sh;
+}

--- a/src/args/make-secret-aws-from-env/template.sh
+++ b/src/args/make-secret-aws-from-env/template.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+
+function main {
+  local access_key_id_name='__argAccessKeyId__'
+  local default_region_name='__argDefaultRegion__'
+  local secret_access_key_name='__argSecretAcessKey__'
+  local session_token_name='__argSessionToken__'
+
+  require_env_var "${access_key_id_name}" \
+    && require_env_var "${default_region_name}" \
+    && require_env_var "${secret_access_key_name}" \
+    && export AWS_ACCESS_KEY_ID="${!access_key_id_name}" \
+    && export AWS_DEFAULT_REGION="${!default_region_name}" \
+    && export AWS_ACCESS_KEY_ID="${!secret_access_key_name}" \
+    && export AWS_SESSION_TOKEN="${!session_token_name:-}"
+}
+
+main "${@}"

--- a/src/args/shell-commands/makes-setup.sh
+++ b/src/args/shell-commands/makes-setup.sh
@@ -30,3 +30,11 @@ function copy {
   cp --no-target-directory --recursive "${@}" \
     && chmod --recursive +w "${@: -1}"
 }
+
+function require_env_var {
+  local var_name="${1}"
+
+  if test -z "${!var_name:-}"; then
+    critical Env var is required but is empty or not present: "${var_name}"
+  fi
+}

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -250,7 +250,10 @@ def _help_and_exit(
         _log()
         _log("[OUTPUT] can be:")
         for attr in attrs:
-            if attr not in {"__all__"}:
+            if attr not in {
+                "__all__",
+                "/secrets/aws/fromEnv/__default__",
+            }:
                 _log(f"  {attr}")
     if exc is not None:
         _log()

--- a/src/evaluator/modules/default.nix
+++ b/src/evaluator/modules/default.nix
@@ -6,5 +6,6 @@ args:
     (import ./inputs.nix)
     (import ./outputs/default.nix args)
     (import ./required-makes-version.nix args)
+    (import ./secrets.nix args)
   ];
 }

--- a/src/evaluator/modules/outputs/builtins/lint-terraform/default.nix
+++ b/src/evaluator/modules/outputs/builtins/lint-terraform/default.nix
@@ -9,9 +9,10 @@
 , ...
 }:
 let
-  makeOutput = name: { src, version }: {
+  makeOutput = name: { authentication, src, version }: {
     name = "/lintTerraform/${name}";
     value = lintTerraform {
+      inherit authentication;
       config = builtins.toFile "tflint.hcl" config.lintTerraform.config;
       inherit name;
       src = path src;
@@ -37,6 +38,10 @@ in
         default = { };
         type = lib.types.attrsOf (lib.types.submodule (_: {
           options = {
+            authentication = lib.mkOption {
+              default = [ ];
+              type = lib.types.listOf lib.types.package;
+            };
             src = lib.mkOption {
               type = lib.types.str;
             };

--- a/src/evaluator/modules/secrets.nix
+++ b/src/evaluator/modules/secrets.nix
@@ -1,0 +1,69 @@
+{ __toModuleOutputs__
+, makeSecretAwsFromEnv
+, ...
+}:
+{ config
+, lib
+, ...
+}:
+let
+  awsFromEnvType = lib.types.submodule (_: {
+    options = {
+      accessKeyId = lib.mkOption {
+        default = "AWS_ACCESS_KEY_ID";
+        type = lib.types.str;
+      };
+      defaultRegion = lib.mkOption {
+        default = "us-east-1";
+        type = lib.types.str;
+      };
+      secretAccessKey = lib.mkOption {
+        default = "AWS_SECRET_ACCESS_KEY";
+        type = lib.types.str;
+      };
+      sessionToken = lib.mkOption {
+        default = "AWS_SESSION_TOKEN";
+        type = lib.types.str;
+      };
+    };
+  });
+  makeAwsFromEnvOutput = name:
+    { accessKeyId
+    , defaultRegion
+    , secretAccessKey
+    , sessionToken
+    }: {
+      name = "/secrets/aws/fromEnv/${name}";
+      value = makeSecretAwsFromEnv {
+        inherit accessKeyId;
+        inherit defaultRegion;
+        inherit name;
+        inherit secretAccessKey;
+        inherit sessionToken;
+      };
+    };
+in
+{
+  options = {
+    secrets = {
+      aws = {
+        fromEnv = lib.mkOption {
+          default = { };
+          type = lib.types.attrsOf awsFromEnvType;
+        };
+      };
+    };
+  };
+  config = {
+    outputs =
+      (__toModuleOutputs__ makeAwsFromEnvOutput config.secrets.aws.fromEnv) //
+      (__toModuleOutputs__ makeAwsFromEnvOutput {
+        __default__ = {
+          accessKeyId = "AWS_ACCESS_KEY_ID";
+          defaultRegion = "us-east-1";
+          secretAccessKey = "AWS_SECRET_ACCESS_KEY";
+          sessionToken = "AWS_SESSION_TOKEN";
+        };
+      });
+  };
+}


### PR DESCRIPTION
- Allow in makes.nix to specify aws secrets from env
  vars
- No secret values are dumped to the nix-store, of course.
  Just env-var names (which are not secret)