### PR TITLE
perf(build): #232 granular paths

### DIFF
--- a/makes/main.nix
+++ b/makes/main.nix
@@ -10,11 +10,12 @@ makeScript {
     "makes-v21.08"
   ];
   replace = {
+    __argCliEntrypoint__ = path "/src/cli/main/__main__.py";
     __argSrc__ = path "/src";
   };
   entrypoint = ''
-    _EVALUATOR=__argSrc__/evaluator \
-    python -m cli.main "$@"
+    _EVALUATOR=__argSrc__/evaluator/default.nix \
+    python __argCliEntrypoint__ "$@"
   '';
   searchPaths = {
     bin = [
@@ -24,9 +25,6 @@ makeScript {
       inputs.nixpkgs.gzip
       inputs.nixpkgs.nix
       inputs.nixpkgs.python38
-    ];
-    pythonPackage = [
-      (path "/src")
     ];
   };
   name = "m";

--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -39,7 +39,7 @@ let
     inherit makesVersion;
     makeTemplate = import ./make-template/default.nix args;
     inherit outputs;
-    path = path: head + path;
+    path = path: builtins.path { name = "src"; path = head + path; };
     pathImpure = path: headImpure + path;
     sortAscii = builtins.sort (a: b: a < b);
     sortAsciiCaseless = builtins.sort (a: b: lib.toLower a < lib.toLower b);

--- a/src/args/make-derivation/default.nix
+++ b/src/args/make-derivation/default.nix
@@ -3,6 +3,7 @@
 , __shellCommands__
 , __shellOptions__
 , makeSearchPaths
+, toDerivationName
 , ...
 }:
 
@@ -59,7 +60,7 @@ builtins.derivation (env' // {
     '')
   ];
   builder = "${__nixpkgs__.bash}/bin/bash";
-  inherit name;
+  name = toDerivationName name;
   system = builtins.currentSystem;
 } // __nixpkgs__.lib.optionalAttrs local {
   allowSubstitutes = false;

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -100,7 +100,6 @@ def _nix_build(
     out: str = "",
     src: str,
 ) -> List[str]:
-    head = f'builtins.path {{ name = "head"; path = {head}; }}'
     substituters = "https://cache.nixos.org " + cache.get("url", "")
     trusted_public_keys = (
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= "
@@ -110,7 +109,7 @@ def _nix_build(
     return [
         "nix-build",
         *_if(is_src_local(src), "--argstr", "headImpure", src),
-        *["--arg", "head", head],
+        *["--argstr", "head", head],
         *["--argstr", "makesVersion", VERSION],
         *["--attr", attr],
         *["--option", "cores", "0"],


### PR DESCRIPTION
- After reading about the differences between all
  ways to load paths, this one is the best:
  - store path depends on content, not names
  - handles unicode and illegal path names well
  - generates a different store path per each
    path instead of a big folder and references
    to it
  - it also allows to load the project lazily instead
    of at startup