### PR TITLE
rever(build): #232 granular paths

### DIFF
--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -6,6 +6,11 @@
 , outputs
 }:
 let
+  head' = builtins.path {
+    name = "head";
+    path = head;
+  };
+
   args = {
     inherit __nixpkgs__;
     __shellCommands__ = ./shell-commands/makes-setup.sh;
@@ -39,7 +44,7 @@ let
     inherit makesVersion;
     makeTemplate = import ./make-template/default.nix args;
     inherit outputs;
-    path = path: builtins.path { name = "src"; path = head + path; };
+    path = path: head' + path;
     pathImpure = path: headImpure + path;
     sortAscii = builtins.sort (a: b: a < b);
     sortAsciiCaseless = builtins.sort (a: b: lib.toLower a < lib.toLower b);


### PR DESCRIPTION
- Seems we need to load the entire HEAD otherwise
  relative paths do not work