### PR TITLE
perf(build): #292 path functions

### DIFF
--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -1,12 +1,12 @@
 { __nixpkgs__
 , head
-, headImpure
+, headMutable
 , inputs
 , makesVersion
 , outputs
 }:
 let
-  head' = builtins.path {
+  headInStore = builtins.path {
     name = "head";
     path = head;
   };
@@ -49,9 +49,10 @@ let
     inherit makesVersion;
     makeTemplate = import ./make-template/default.nix args;
     inherit outputs;
-    path = path: head' + path;
+    path = rel: headInStore + rel;
+    pathCopy = rel: builtins.path { name = "src"; path = head + rel; };
+    pathMutable = rel: headMutable + rel;
     pathsMatching = import ./paths-matching/default.nix args;
-    pathImpure = path: headImpure + path;
     sortAscii = builtins.sort (a: b: a < b);
     sortAsciiCaseless = builtins.sort (a: b: lib.toLower a < lib.toLower b);
     testTerraform = import ./test-terraform/default.nix args;

--- a/src/args/format-bash/default.nix
+++ b/src/args/format-bash/default.nix
@@ -1,7 +1,7 @@
 { __nixpkgs__
 , asBashArray
 , makeScript
-, pathImpure
+, pathMutable
 , ...
 }:
 { name
@@ -11,7 +11,7 @@
 makeScript {
   replace = {
     __argTargets__ = asBashArray
-      (builtins.map pathImpure targets);
+      (builtins.map pathMutable targets);
   };
   name = "format-bash-for-${name}";
   searchPaths = {

--- a/src/args/format-terraform/default.nix
+++ b/src/args/format-terraform/default.nix
@@ -1,7 +1,7 @@
 { __nixpkgs__
 , asBashArray
 , makeScript
-, pathImpure
+, pathMutable
 , ...
 }:
 { name
@@ -11,7 +11,7 @@
 makeScript {
   replace = {
     __argTargets__ = asBashArray
-      (builtins.map pathImpure targets);
+      (builtins.map pathMutable targets);
   };
   name = "format-terraform-for-${name}";
   searchPaths = {

--- a/src/args/paths-matching/default.nix
+++ b/src/args/paths-matching/default.nix
@@ -6,8 +6,11 @@
 , target
 }:
 let
+  root = path "";
   allFiles = __nixpkgs__.lib.filesystem.listFilesRecursive (path target);
   matchesRegex = string: builtins.match regex string != null;
-  matchedFiles = builtins.filter matchesRegex allFiles;
+  matchedFiles = builtins.map
+    (__nixpkgs__.lib.removePrefix root)
+    (builtins.filter matchesRegex allFiles);
 in
-builtins.map (__nixpkgs__.lib.removePrefix (path "")) matchedFiles
+builtins.map builtins.unsafeDiscardStringContext matchedFiles

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -108,7 +108,7 @@ def _nix_build(
 
     return [
         "nix-build",
-        *_if(is_src_local(src), "--argstr", "headImpure", src),
+        *_if(is_src_local(src), "--argstr", "headMutable", src),
         *["--argstr", "head", head],
         *["--argstr", "makesVersion", VERSION],
         *["--attr", attr],

--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -4,7 +4,7 @@
   head
   # Path to the user's project, outside the sandbox.
   # Only available when running local Makes projects.
-, headImpure ? head
+, headMutable ? head
   # Makes version that is invoking the project
 , makesVersion
 , ...
@@ -13,7 +13,7 @@ let
   args = import ../args/default.nix {
     __nixpkgs__ = packages.nixpkgs;
     inherit head;
-    inherit headImpure;
+    inherit headMutable;
     inputs = result.config.inputs;
     inherit makesVersion;
     outputs = result.config.outputs;

--- a/src/evaluator/modules/outputs/builtins/format-markdown/default.nix
+++ b/src/evaluator/modules/outputs/builtins/format-markdown/default.nix
@@ -2,7 +2,7 @@
 , asBashArray
 , makeNodeEnvironment
 , makeScript
-, pathImpure
+, pathMutable
 , ...
 }:
 { config
@@ -32,7 +32,7 @@
           __argDoctocArgs__ = asBashArray
             config.formatMarkdown.doctocArgs;
           __argTargets__ = asBashArray
-            (builtins.map pathImpure config.formatMarkdown.targets);
+            (builtins.map pathMutable config.formatMarkdown.targets);
         };
         name = "format-markdown";
         searchPaths = {

--- a/src/evaluator/modules/outputs/builtins/format-nix/default.nix
+++ b/src/evaluator/modules/outputs/builtins/format-nix/default.nix
@@ -1,7 +1,7 @@
 { __nixpkgs__
 , asBashArray
 , makeScript
-, pathImpure
+, pathMutable
 , ...
 }:
 { config
@@ -26,7 +26,7 @@
       "/formatNix" = lib.mkIf config.formatNix.enable (makeScript {
         replace = {
           __argTargets__ = asBashArray
-            (builtins.map pathImpure config.formatNix.targets);
+            (builtins.map pathMutable config.formatNix.targets);
         };
         name = "format-nix";
         searchPaths = {

--- a/src/evaluator/modules/outputs/builtins/format-python/default.nix
+++ b/src/evaluator/modules/outputs/builtins/format-python/default.nix
@@ -1,7 +1,7 @@
 { __nixpkgs__
 , asBashArray
 , makeScript
-, pathImpure
+, pathMutable
 , ...
 }:
 { config
@@ -28,7 +28,7 @@
           __argSettingsBlack__ = ./settings-black.toml;
           __argSettingsIsort__ = ./settings-isort.toml;
           __argTargets__ = asBashArray
-            (builtins.map pathImpure config.formatPython.targets);
+            (builtins.map pathMutable config.formatPython.targets);
         };
         name = "format-python";
         searchPaths = {

--- a/src/evaluator/modules/outputs/builtins/lint-git-mailmap/default.nix
+++ b/src/evaluator/modules/outputs/builtins/lint-git-mailmap/default.nix
@@ -1,5 +1,5 @@
 { lintGitMailMap
-, pathImpure
+, pathMutable
 , ...
 }:
 { lib
@@ -18,7 +18,7 @@
     outputs = {
       "/lintGitMailMap" = lintGitMailMap {
         name = "lint-git-mailmap";
-        src = pathImpure "/";
+        src = pathMutable "/";
       };
     };
   };


### PR DESCRIPTION
- Design the API for loading paths from the project
- Add pathCopy which copies the path and everything
  under it to the store, useful for performance
- Keep path as it is
- Rename pathImpure to pathMutable, this name
  represents better what it returns: a path
  that you can modify in-place in the project
  (used mostly for formatters)
- Remove all possible context from pathsMatching
  so it returns bare strings