### PR TITLE
fix(build): #0 allow pining args too

### DIFF
--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -21,13 +21,6 @@
 , ...
 }:
 let
-  args = import ../args/default.nix {
-    __nixpkgs__ = packages.nixpkgs;
-    inherit projectSrc;
-    inherit projectSrcMutable;
-    inputs = result.config.inputs;
-    outputs = result.config.outputs;
-  };
   packages = import ../nix/packages.nix;
   result =
     let
@@ -53,7 +46,13 @@ let
         ("${makesSrcOverriden}/src/evaluator/modules/default.nix")
         (makesNix)
       ];
-      specialArgs = args;
+      specialArgs = import "${makesSrcOverriden}/src/args/default.nix" {
+        __nixpkgs__ = packages.nixpkgs;
+        inherit projectSrc;
+        inherit projectSrcMutable;
+        inputs = result.config.inputs;
+        outputs = result.config.outputs;
+      };
     };
 in
 result


### PR DESCRIPTION
- Allow pining arguments too, we were using
  the latest version bundled with the CLI