### PR TITLE
perf(build): #0 reproducibility of root

### DIFF
--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -56,7 +56,7 @@ let
     optionalAttrs = lib.optionalAttrs;
     inherit outputs;
     inherit projectSrc;
-    projectPath = rel: builtins.path { path = projectSrc + rel; };
+    projectPath = import ./project-path/default.nix args;
     projectPathLsDirs = import ./project-path-ls-dirs/default.nix args;
     projectPathMutable = rel: projectSrcMutable + rel;
     projectPathsMatching = import ./project-paths-matching/default.nix args;

--- a/src/args/project-path/default.nix
+++ b/src/args/project-path/default.nix
@@ -1,0 +1,12 @@
+{ hasPrefix
+, projectSrc
+, ...
+}:
+rel:
+if hasPrefix "/" rel
+then
+  (builtins.path {
+    name = if rel == "/" then "src" else builtins.baseNameOf rel;
+    path = projectSrc + rel;
+  })
+else abort "projectPath arguments must start with: /, currently it is: ${rel}"


### PR DESCRIPTION
- Make the root path not depend on the folder name,
  which may vary from machine to machine