### PR TITLE
refac(build): #426 force tf 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ Types:
       Defaults to `[ ]`.
     - src (`str`):
       Path to the [Terraform][TERRAFORM] module.
-    - version (`enum [ "0.12" "0.13" "0.14" "0.15" "0.16" ]`):
+    - version (`enum [ "0.14" "0.15" "0.16" ]`):
       [Terraform][TERRAFORM] version your module is built with.
 
 Example `makes.nix`:
@@ -1221,7 +1221,7 @@ Types:
       Defaults to `[ ]`.
     - src (`str`):
       Path to the [Terraform][TERRAFORM] module.
-    - version (`enum [ "0.12" "0.13" "0.14" "0.15" "0.16" ]`):
+    - version (`enum [ "0.14" "0.15" "0.16" ]`):
       [Terraform][TERRAFORM] version your module is built with.
     - debug (`bool`): Optional.
       Enable maximum level of debugging
@@ -1376,7 +1376,7 @@ Types:
       Defaults to `[ ]`.
     - src (`str`):
       Path to the [Terraform][TERRAFORM] module.
-    - version (`enum [ "0.12" "0.13" "0.14" "0.15" "0.16" ]`):
+    - version (`enum [ "0.14" "0.15" "0.16" ]`):
       [Terraform][TERRAFORM] version your module is built with.
 
 Example `makes.nix`:
@@ -1428,7 +1428,7 @@ Types:
       Defaults to `[ ]`.
     - src (`str`):
       Path to the [Terraform][TERRAFORM] module.
-    - version (`enum [ "0.12" "0.13" "0.14" "0.15" "0.16" ]`):
+    - version (`enum [ "0.14" "0.15" "0.16" ]`):
       [Terraform][TERRAFORM] version your module is built with.
 
 Example `makes.nix`:

--- a/src/evaluator/modules/deploy-terraform/default.nix
+++ b/src/evaluator/modules/deploy-terraform/default.nix
@@ -35,8 +35,6 @@ in
             };
             version = lib.mkOption {
               type = lib.types.enum [
-                "0.12"
-                "0.13"
                 "0.14"
                 "0.15"
                 "0.16"

--- a/src/evaluator/modules/lint-terraform/default.nix
+++ b/src/evaluator/modules/lint-terraform/default.nix
@@ -47,8 +47,6 @@ in
             };
             version = lib.mkOption {
               type = lib.types.enum [
-                "0.12"
-                "0.13"
                 "0.14"
                 "0.15"
                 "0.16"

--- a/src/evaluator/modules/taint-terraform/default.nix
+++ b/src/evaluator/modules/taint-terraform/default.nix
@@ -44,8 +44,6 @@ in
             };
             version = lib.mkOption {
               type = lib.types.enum [
-                "0.12"
-                "0.13"
                 "0.14"
                 "0.15"
                 "0.16"

--- a/src/evaluator/modules/test-terraform/default.nix
+++ b/src/evaluator/modules/test-terraform/default.nix
@@ -40,8 +40,6 @@ in
             };
             version = lib.mkOption {
               type = lib.types.enum [
-                "0.12"
-                "0.13"
                 "0.14"
                 "0.15"
                 "0.16"


### PR DESCRIPTION
- Force terraform to be >= 0.14 in order to
  prevent customers from using terraform versions
  vulnerable to supply chain attacks