### PR TITLE
feat(build): #0 make python pypi mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Real life projects that run entirely on [Makes][MAKES]:
             - [makeNodeJsEnvironment](#makenodejsenvironment)
         - [Python](#python)
             - [makePythonVersion](#makepythonversion)
+            - [makePythonPypiMirror](#makepythonpypimirror)
             - [makePythonEnvironment](#makepythonenvironment)
         - [Containers](#containers)
             - [makeContainerImage](#makecontainerimage)
@@ -2749,6 +2750,59 @@ $ m . /example
     Python 3.8.9
 ```
 
+#### makePythonPypiMirror
+
+Copy the required installers
+for a set of [Python][PYTHON] packages
+from the [Python Packaging Index (PyPI)][PYTHON_PYPI]
+in PEP 503 format.
+
+Types:
+
+- makePythonPypiMirror (`function { ... } -> package`):
+
+    - name (`str`):
+      Custom name to assign to the build step, be creative, it helps in debugging.
+    - dependencies (`attrsOf str`):
+      Mapping of packages to versions.
+    - subDependencies (`attrsOf str`): Optional.
+      Mapping of packages to versions.
+      In order to get the complete list of sub-dependencies
+      you can omit this parameter and execute Makes.
+      Makes will tell you this information on failure.
+      Defaults to `{ }`.
+    - python (`package`):
+      [Python][PYTHON] interpreter to use.
+      For example: `makePythonVersion "3.8"`.
+    - sha256 (`str`):
+      SHA256 of the expected output,
+      In order to get the SHA256
+      you can omit this parameter and execute Makes.
+      Makes will tell you the correct SHA256 on failure.
+
+Example:
+
+```nix
+# /path/to/my/project/makes/example/main.nix
+{ makePythonPypiMirror
+, makePythonVersion
+, ...
+}:
+makePythonPypiMirror {
+  name = "example";
+  dependencies = {
+    "django" = "3.2.6";
+  };
+  subDependencies = {
+    "asgiref" = "3.4.1";
+    "pytz" = "2021.1";
+    "sqlparse" = "0.4.1";
+  };
+  python = makePythonVersion "3.8";
+  sha256 = "0x5qa0m5bhfqcpk4gj2n8rgffvx2msnbgx5jmawjdpz11lamc377";
+}
+```
+
 #### makePythonEnvironment
 
 Create an environment where python dependencies are available
@@ -3599,6 +3653,9 @@ Examples:
 
 - [PYTHONPATH]: https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH
   [PYTHONPATH Environment Variable][PYTHONPATH]
+
+- [PYTHON_PYPI]: https://pypi.org/
+  [Python Packaging Index (PyPI)][PYTHON_PYPI]
 
 - [RAKE]: https://github.com/ruby/rake
   [Rake][RAKE]

--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -34,6 +34,7 @@ let
     gitlabCi = import ./gitlab-ci/default.nix;
     hasPrefix = lib.strings.hasPrefix;
     inherit inputs;
+    listOptional = lib.lists.optional;
     lintClojure = import ./lint-clojure/default.nix args;
     lintGitCommitMsg = import ./lint-git-commit-msg/default.nix args;
     lintGitMailMap = import ./lint-git-mailmap/default.nix args;
@@ -51,6 +52,7 @@ let
     makeNodeJsModules = import ./make-node-js-modules/default.nix args;
     makeNodeJsVersion = import ./make-node-js-version/default.nix args;
     makePythonEnvironment = import ./make-python-environment/default.nix args;
+    makePythonPypiMirror = import ./make-python-pypi-mirror/default.nix args;
     makePythonVersion = import ./make-python-version/default.nix args;
     makeScript = import ./make-script/default.nix args;
     makeScriptParallel = import ./make-script-parallel/default.nix args;

--- a/src/args/make-python-environment/default.nix
+++ b/src/args/make-python-environment/default.nix
@@ -1,7 +1,9 @@
 { __nixpkgs__
 , getAttr
 , toFileLst
+, listOptional
 , makeDerivation
+, makePythonVersion
 , makeSearchPaths
 , sortAsciiCaseless
 , ...
@@ -50,7 +52,7 @@ let
 in
 makeSearchPaths {
   bin = [ pythonEnvironment ];
-  pythonPackage37 = if (python == "3.7") then [ pythonEnvironment ] else [ ];
-  pythonPackage38 = if (python == "3.8") then [ pythonEnvironment ] else [ ];
-  pythonPackage39 = if (python == "3.9") then [ pythonEnvironment ] else [ ];
+  pythonPackage37 = listOptional (python == makePythonVersion "3.7") pythonEnvironment;
+  pythonPackage38 = listOptional (python == makePythonVersion "3.8") pythonEnvironment;
+  pythonPackage39 = listOptional (python == makePythonVersion "3.9") pythonEnvironment;
 }

--- a/src/args/make-python-pypi-mirror/builder.sh
+++ b/src/args/make-python-pypi-mirror/builder.sh
@@ -1,0 +1,29 @@
+# shellcheck shell=bash
+
+function main {
+  python -m venv venv \
+    && source venv/bin/activate \
+    && pip download \
+      --abi none \
+      --cache-dir . \
+      --dest downloads \
+      --disable-pip-version-check \
+      --implementation py \
+      --no-python-version-warning \
+      --only-binary=:all: \
+      --platform any \
+      --pre \
+      --progress-bar ascii \
+      --requirement "${envDeps}" \
+      --requirement "${envSubDeps}" \
+    && pypi-mirror create \
+      --copy \
+      --download-dir downloads \
+      --mirror-dir "${out}/mirror" \
+    && copy "${envDeps}" "${out}/deps.txt" \
+    && copy "${envSubDeps}" "${out}/sub-deps.txt" \
+    && python "${envCheckCompleteness}" \
+      "${out}/mirror" "${envDeps}" "${envSubDeps}"
+}
+
+main "${@}"

--- a/src/args/make-python-pypi-mirror/check-completeness.py
+++ b/src/args/make-python-pypi-mirror/check-completeness.py
@@ -1,0 +1,78 @@
+import os
+import sys
+from typing import (
+    Set,
+)
+
+
+def main() -> None:
+    # Compute requirements
+    closure: Set[str] = list_requirements_in_mirror(sys.argv[1])
+    deps: Set[str] = load_requirements_txt(sys.argv[2])
+    sub_deps: Set[str] = load_requirements_txt(sys.argv[3])
+
+    print("Downloaded packages:")
+    for dep in sorted(closure):
+        print(f"  {dep}")
+
+    error_on_non_canonical_names(closure, deps, sub_deps)
+    error_on_missing_sub_deps(closure, deps, sub_deps)
+
+
+def error_on_non_canonical_names(
+    closure: Set[str],
+    deps: Set[str],
+    sub_deps: Set[str],
+) -> None:
+    non_canonical: Set[str] = {
+        dep for dep in sorted(deps | sub_deps) if dep not in closure
+    }
+    if non_canonical:
+        print()
+        print("Names can only contain: lowercase letters, numbers and dashes")
+        for dep in non_canonical:
+            print(f"  {dep}")
+        sys.exit(1)
+
+
+def error_on_missing_sub_deps(
+    closure: Set[str],
+    deps: Set[str],
+    sub_deps: Set[str],
+) -> None:
+    missing_sub_deps: Set[str] = {
+        dep for dep in closure if dep not in deps and dep not in sub_deps
+    }
+    if missing_sub_deps:
+        print()
+        print("Please add as sub-dependencies:")
+        for dep in sorted(missing_sub_deps):
+            print(f"  {dep}")
+        sys.exit(1)
+
+
+def format_pkg(name: str, version: str) -> str:
+    return f'"{name}" = "{version}";'
+
+
+def load_requirements_txt(path: str) -> Set[str]:
+    with open(path) as handle:
+        return set(
+            format_pkg(*pkg.split("==")) for pkg in handle.read().splitlines()
+        )
+
+
+def list_requirements_in_mirror(path: str) -> Set[str]:
+    all: Set[str] = set()
+    for pkg in os.listdir(path):
+        if pkg != "index.html":
+            for pkg_src in os.listdir(os.path.join(path, pkg)):
+                if pkg_src != "index.html":
+                    _, pkg_version, *_ = pkg_src.split("-")
+                    all.add(format_pkg(pkg, pkg_version))
+                    break
+    return all
+
+
+if __name__ == "__main__":
+    main()

--- a/src/args/make-python-pypi-mirror/default.nix
+++ b/src/args/make-python-pypi-mirror/default.nix
@@ -1,0 +1,42 @@
+{ __nixpkgs__
+, attrsMapToList
+, fakeSha256
+, makeDerivation
+, makePythonEnvironment
+, makePythonVersion
+, toFileLst
+, ...
+}:
+{ dependencies ? { }
+, name
+, python
+, sha256 ? fakeSha256
+, subDependencies ? { }
+}:
+let
+  toReqsTxt = dependencies:
+    toFileLst "requirements.txt"
+      (attrsMapToList (req: version: "${req}==${version}") dependencies);
+
+  pythonPypiMirror = makePythonEnvironment {
+    name = "python-pypi-mirror";
+    dependencies = [
+      "python-pypi-mirror==4.0.6"
+    ];
+    python = makePythonVersion "3.8";
+  };
+in
+makeDerivation {
+  env = {
+    envCheckCompleteness = ./check-completeness.py;
+    envDeps = toReqsTxt dependencies;
+    envSubDeps = toReqsTxt subDependencies;
+  };
+  builder = ./builder.sh;
+  name = "make-python-pypi-mirror-for-${name}";
+  inherit sha256;
+  searchPaths = {
+    bin = [ __nixpkgs__.findutils python ];
+    source = [ pythonPypiMirror ];
+  };
+}


### PR DESCRIPTION
- Add a new argument that allows to mirror pypi
  in a pure way, it works as a fixed-output derivation
  and forces downloaded contents to be protected by a hash
- This allows us to enable sand-boxing and pure evaluation in Makes,
  which is a feature we dropped by design a few years ago for keeping
  things usable in the enterprise world