### PR TITLE
feat(build): #0 make python pypi env

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Real life projects that run entirely on [Makes][MAKES]:
         - [Python](#python)
             - [makePythonVersion](#makepythonversion)
             - [makePythonPypiMirror](#makepythonpypimirror)
+            - [makePythonPypiEnvironment](#makepythonpypienvironment)
             - [makePythonEnvironment](#makepythonenvironment)
         - [Containers](#containers)
             - [makeContainerImage](#makecontainerimage)
@@ -2799,6 +2800,66 @@ makePythonPypiMirror {
     "sqlparse" = "0.4.1";
   };
   python = makePythonVersion "3.8";
+  sha256 = "0x5qa0m5bhfqcpk4gj2n8rgffvx2msnbgx5jmawjdpz11lamc377";
+}
+```
+
+#### makePythonPypiEnvironment
+
+Create a virtual environment
+where the provided set of [Python][PYTHON] packages
+from the [Python Packaging Index (PyPI)][PYTHON_PYPI]
+are installed.
+
+Types:
+
+- makePythonPypiEnvironment (`function { ... } -> package`):
+
+    - name (`str`):
+      Custom name to assign to the build step, be creative, it helps in debugging.
+    - dependencies (`attrsOf str`):
+      Mapping of packages to versions.
+    - subDependencies (`attrsOf str`): Optional.
+      Mapping of packages to versions.
+      In order to get the complete list of sub-dependencies
+      you can omit this parameter and execute Makes.
+      Makes will tell you this information on failure.
+      Defaults to `{ }`.
+    - python (`package`):
+      [Python][PYTHON] interpreter to use.
+      For example: `makePythonVersion "3.8"`.
+    - sha256 (`str`):
+      SHA256 of the expected output,
+      In order to get the SHA256
+      you can omit this parameter and execute Makes.
+      Makes will tell you the correct SHA256 on failure.
+    - searchPaths (`asIn makeSearchPaths`): Optional.
+      Arguments here will be passed as-is to `makeSearchPaths`.
+      Defaults to `makeSearchPaths`'s defaults.
+
+Example:
+
+```nix
+# /path/to/my/project/makes/example/main.nix
+{ inputs
+, makePythonPypiEnvironment
+, makePythonVersion
+, ...
+}:
+makePythonPypiEnvironment {
+  name = "example";
+  dependencies = {
+    "django" = "3.2.6";
+  };
+  subDependencies = {
+    "asgiref" = "3.4.1";
+    "pytz" = "2021.1";
+    "sqlparse" = "0.4.1";
+  };
+  python = makePythonVersion "3.8";
+  searchPaths = {
+    bin = [ inputs.nixpkgs.gcc ];
+  };
   sha256 = "0x5qa0m5bhfqcpk4gj2n8rgffvx2msnbgx5jmawjdpz11lamc377";
 }
 ```

--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -52,6 +52,7 @@ let
     makeNodeJsModules = import ./make-node-js-modules/default.nix args;
     makeNodeJsVersion = import ./make-node-js-version/default.nix args;
     makePythonEnvironment = import ./make-python-environment/default.nix args;
+    makePythonPypiEnvironment = import ./make-python-pypi-environment/default.nix args;
     makePythonPypiMirror = import ./make-python-pypi-mirror/default.nix args;
     makePythonVersion = import ./make-python-version/default.nix args;
     makeScript = import ./make-script/default.nix args;

--- a/src/args/make-python-pypi-environment/builder.sh
+++ b/src/args/make-python-pypi-environment/builder.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+function main {
+  python -m venv "${out}" \
+    && source "${out}/bin/activate" \
+    && HOME=. python -m pip install \
+      --cache-dir . \
+      --index-url "file://${envMirror}/mirror" \
+      --requirement "${envMirror}/deps.txt" \
+      --requirement "${envMirror}/sub-deps.txt"
+}
+
+main "${@}"

--- a/src/args/make-python-pypi-environment/default.nix
+++ b/src/args/make-python-pypi-environment/default.nix
@@ -1,0 +1,38 @@
+{ fakeSha256
+, getAttr
+, listOptional
+, makeDerivation
+, makePythonPypiMirror
+, makePythonVersion
+, makeSearchPaths
+, ...
+}:
+{ dependencies ? { }
+, name
+, python
+, sha256 ? fakeSha256
+, searchPaths ? { }
+, subDependencies ? { }
+}:
+let
+  pypiEnvironment = makeDerivation {
+    builder = ./builder.sh;
+    env.envMirror = makePythonPypiMirror {
+      inherit dependencies;
+      inherit name;
+      inherit python;
+      inherit sha256;
+      inherit subDependencies;
+    };
+    inherit name;
+    searchPaths = searchPaths // {
+      bin = (getAttr searchPaths "bin" [ ]) ++ [ python ];
+    };
+  };
+in
+makeSearchPaths {
+  bin = [ pypiEnvironment ];
+  pythonPackage37 = listOptional (python == makePythonVersion "3.7") pypiEnvironment;
+  pythonPackage38 = listOptional (python == makePythonVersion "3.8") pypiEnvironment;
+  pythonPackage39 = listOptional (python == makePythonVersion "3.9") pypiEnvironment;
+}


### PR DESCRIPTION
- Add a new argument that allows to create
  a virtual environment with packages from
  pypi in a pure way (using fixed-output
  derivations)
- This will allows us to enable sandboxing soon
  (pending to migrate npm packages)