### PR TITLE
fix(build): #0 avoid empty names

### DIFF
--- a/src/args/from-yaml/default.nix
+++ b/src/args/from-yaml/default.nix
@@ -3,8 +3,7 @@
 , ...
 }:
 expr:
-fromJson (
-  builtins.readFile (
-    toFileJsonFromFileYaml (
-      builtins.toFile "" expr
-    )))
+fromJson
+  (builtins.readFile
+    (toFileJsonFromFileYaml
+      (builtins.toFile "src" expr)))


### PR DESCRIPTION
- Empty names are forbidden in nix 3