### PR TITLE
fix(back): #464 disable shopt

### DIFF
--- a/src/args/make-secret-for-env-from-sops/template.sh
+++ b/src/args/make-secret-for-env-from-sops/template.sh
@@ -1,15 +1,18 @@
 # shellcheck shell=bash
 
+# This function temporarily disables xpg_echo as it breaks sops escaping
 function main {
   source __argVars__/template local vars
 
   info Making secrets for env from sops for __argName__: \
-    && decrypted=$(sops --decrypt --output-type json '__argManifest__') \
+    && shopt -u xpg_echo \
+    && decrypted="$(sops --decrypt --output-type json '__argManifest__')" \
     && for var in "${vars[@]}"; do
       info - "${var}" \
         && export "${var//./__}=$(echo "${decrypted}" | jq -erc ".${var}")" \
         || return 1
-    done
+    done \
+    && shopt -s xpg_echo
 }
 
 main "${@}"


### PR DESCRIPTION
- Disable shopt xpg_echo
in make-secret-for-env-from-sops
as it breaks sops escaping