### PR TITLE
refac(build): #434 use nixpkgs fetch

### DIFF
--- a/src/args/make-python-pypi-environment/default.nix
+++ b/src/args/make-python-pypi-environment/default.nix
@@ -37,7 +37,7 @@ let
       envDownloads = __nixpkgs__.linkFarm name (builtins.map
         ({ name, sha256, url }: {
           inherit name;
-          path = builtins.fetchurl {
+          path = __nixpkgs__.fetchurl {
             inherit name;
             inherit sha256;
             inherit url;


### PR DESCRIPTION
- Fetch with nixpkgs instead with the builtin,
  maybe the builtin is bugged?