### PR TITLE
fix(build): #434 upgrade pip

### DIFF
--- a/src/args/make-python-pypi-environment/builder.sh
+++ b/src/args/make-python-pypi-environment/builder.sh
@@ -1,16 +1,20 @@
 # shellcheck shell=bash
 
 function main {
+  local pip_install=(
+    python -m pip install
+    --cache-dir .
+    --index-url "file://${PWD}/mirror"
+    --no-deps
+  )
+
   pypi-mirror create \
     --download-dir "${envDownloads}" \
     --mirror-dir mirror \
     && python -m venv "${out}" \
     && source "${out}/bin/activate" \
-    && HOME=. python -m pip install \
-      --cache-dir . \
-      --index-url "file://${PWD}/mirror" \
-      --no-deps \
-      --requirement "${envClosure}"
+    && HOME=. "${pip_install[@]}" --upgrade pip \
+    && HOME=. "${pip_install[@]}" --requirement "${envClosure}"
 }
 
 main "${@}"

--- a/src/args/make-python-pypi-environment/default.nix
+++ b/src/args/make-python-pypi-environment/default.nix
@@ -91,6 +91,16 @@ let
             sha256 = "0p4i5nypfdqzjlmlkwvy45107y7kpq3x9s5zq2jl9vwd3iq5zgf3";
             url = "https://files.pythonhosted.org/packages/py3/s/setuptools_scm/setuptools_scm-6.0.1-py3-none-any.whl";
           })
+          (listOptional withWheel_0_37_0 {
+            name = "wheel-0.37.0-py2.py3-none-any.whl";
+            sha256 = "1za6c4s0yjy1dzprmib3kph40hr8xgj3apdsnqs00v9wv4mln091";
+            url = "https://pypi.org/packages/py2.py3/w/wheel/wheel-0.37.0-py2.py3-none-any.whl";
+          })
+          (listOptional true {
+            name = "pip-21.2.4-py3-none-any.whl";
+            sha256 = "fa9ebb85d3fd607617c0c44aca302b1b45d87f9c2a1649b46c26167ca4296323";
+            url = "https://files.pythonhosted.org/packages/ca/31/b88ef447d595963c01060998cb329251648acf4a067721b0452c45527eb8/pip-21.2.4-py3-none-any.whl";
+          })
         ]));
     };
     inherit name;


### PR DESCRIPTION
- Old versions of pip do not handle zips
  with timestamps before 1980 well, later
  versions does, so lets upgrade