### PR TITLE
feat(build): #434 include abi3

### DIFF
--- a/makes/utils/makePythonPypiEnvironmentSources/entrypoint.sh
+++ b/makes/utils/makePythonPypiEnvironmentSources/entrypoint.sh
@@ -72,7 +72,10 @@ function main {
               *) ;;
             esac \
             && if ! in_array "${python_versions[${index}]}" "${implementations[@]}"; then
-              continue
+              case "${file}" in
+                *-abi3-*.whl) ;;
+                *) continue ;;
+              esac
             fi \
             && url="${urls[${index}]}" \
             && sha256="$(nix-prefetch-url --name "${file}" --type sha256 "${url}")" \


### PR DESCRIPTION
- abi3 wheels are compatible with all python3 versions
- This allows to install cryptography without the rust
  toolchain which is very cumbersome