### PR TITLE
feat(build): #494 prototype npm pkging

### DIFF
--- a/src/args/agnostic.nix
+++ b/src/args/agnostic.nix
@@ -49,6 +49,8 @@ let
     makeDerivationParallel = import ./make-derivation-parallel/default.nix args;
     makeEnvVars = import ./make-env-vars/default.nix args;
     makeEnvVarsForTerraform = import ./make-env-vars-for-terraform/default.nix args;
+    makeNodeJsNpmEnvironmentPure = import ./make-node-js-environment-pure/default.nix args;
+    makeNodeJsVersion = import ./make-node-js-version/default.nix args;
     makePythonPypiEnvironment = import ./make-python-pypi-environment/default.nix args;
     makePythonVersion = import ./make-python-version/default.nix args;
     makeScript = import ./make-script/default.nix args;

--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -25,7 +25,6 @@ let
     lintWithAjv = import ./lint-with-ajv/default.nix args;
     makeNodeJsEnvironment = import ./make-node-js-environment/default.nix args;
     makeNodeJsModules = import ./make-node-js-modules/default.nix args;
-    makeNodeJsVersion = import ./make-node-js-version/default.nix args;
   };
 in
 args

--- a/src/args/make-node-js-environment-pure/builder.sh
+++ b/src/args/make-node-js-environment-pure/builder.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+
+function main {
+  local ephemeral
+
+  ephemeral="$(mktemp -d)" \
+    && mkdir "${out}" \
+    && cd "${out}" \
+    && jq -er < "${envPackageLockJson}" \
+    && copy "${envPackageLockJson}" package-lock.json \
+    && HOME="${ephemeral}" npm install
+}
+
+main "${@}"

--- a/src/args/make-node-js-environment-pure/default.nix
+++ b/src/args/make-node-js-environment-pure/default.nix
@@ -1,0 +1,45 @@
+{ __nixpkgs__
+, fromJsonFile
+, toFileJson
+, makeDerivation
+, makeNodeJsVersion
+, ...
+}:
+{ name
+, nodeJsVersion
+, packageLockJson
+, ...
+}:
+let
+  nodeJs = makeNodeJsVersion nodeJsVersion;
+  packageLock = fromJsonFile packageLockJson;
+
+  nixifyDependencies = builtins.mapAttrs
+    (_: dependencyParams:
+      (builtins.removeAttrs dependencyParams [ "resolved" ]) // {
+        dependencies =
+          if builtins.hasAttr "dependencies" dependencyParams
+          then nixifyDependencies dependencyParams.dependencies
+          else { };
+        version =
+          let file = __nixpkgs__.fetchurl {
+            hash = dependencyParams.integrity;
+            url = dependencyParams.resolved;
+          };
+          in "file:${file}";
+      });
+
+  packageLockNixified = packageLock // {
+    dependencies = nixifyDependencies packageLock.dependencies;
+  };
+in
+makeDerivation {
+  builder = ./builder.sh;
+  env = {
+    envPackageLockJson = toFileJson "package-lock.json" packageLockNixified;
+  };
+  name = "make-node-js-environment-for-${name}";
+  searchPaths = {
+    bin = [ __nixpkgs__.jq nodeJs ];
+  };
+}


### PR DESCRIPTION
- I think we can package npm **purely** by turning package-lock.json
  into a manifest with references to the nix store
- Start by nixifying the urls pointing at the
  registry