### PR TITLE
feat(build): #494 search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2642,6 +2642,9 @@ Types:
       Path to the `package.json` of your project.
     - packageLockJson (`package`):
       Path to the `package-lock.json` of your project.
+    - searchPaths (`asIn makeSearchPaths`): Optional.
+      Arguments here will be passed as-is to `makeSearchPaths`.
+      Defaults to `makeSearchPaths`'s defaults.
 
 Example:
 
@@ -2725,6 +2728,9 @@ Types:
       Path to the `package.json` of your project.
     - packageLockJson (`package`):
       Path to the `package-lock.json` of your project.
+    - searchPaths (`asIn makeSearchPaths`): Optional.
+      Arguments here will be passed as-is to `makeSearchPaths`.
+      Defaults to `makeSearchPaths`'s defaults.
 
 Example:
 

--- a/src/args/make-node-js-environment/default.nix
+++ b/src/args/make-node-js-environment/default.nix
@@ -9,6 +9,7 @@
 , nodeJsVersion
 , packageJson
 , packageLockJson
+, searchPaths ? { }
 }:
 let
   node = makeNodeJsVersion nodeJsVersion;
@@ -17,6 +18,7 @@ let
     inherit nodeJsVersion;
     inherit packageJson;
     inherit packageLockJson;
+    inherit searchPaths;
   };
 
   dotBin = __nixpkgs__.linkFarm "make-node-js-environment-for-${name}"
@@ -28,4 +30,5 @@ makeSearchPaths {
   bin = [ node ];
   nodeBin = [ dotBin nodeModules ];
   nodeModule = [ nodeModules ];
+  source = [ (makeSearchPaths searchPaths) ];
 }

--- a/src/args/make-node-js-modules/default.nix
+++ b/src/args/make-node-js-modules/default.nix
@@ -3,6 +3,7 @@
 , fromJsonFile
 , makeDerivation
 , makeNodeJsVersion
+, makeSearchPaths
 , toFileJson
 , ...
 }:
@@ -10,6 +11,7 @@
 , nodeJsVersion
 , packageJson
 , packageLockJson
+, searchPaths ? { }
 }:
 let
   nodeJs = makeNodeJsVersion nodeJsVersion;
@@ -81,6 +83,7 @@ makeDerivation {
   };
   name = "make-node-js-modules-for-${name}";
   searchPaths = {
-    bin = [ __nixpkgs__.python39 nodeJs ];
+    bin = [ __nixpkgs__.bash __nixpkgs__.python39 nodeJs ];
+    source = [ (makeSearchPaths searchPaths) ];
   };
 }


### PR DESCRIPTION
- For building special packages we need to
  pass compilers down the road
- Add bash as bootstrapped dependency, it
  is required many times