### PR TITLE
fix(back): #449 patch shebangs

### DIFF
--- a/src/args/make-node-js-modules/builder.sh
+++ b/src/args/make-node-js-modules/builder.sh
@@ -1,5 +1,14 @@
 # shellcheck disable=SC2015 shell=bash
 
+function patch_shebang {
+  local path="${1}"
+  local regex='#! /usr/bin/env node'
+  local replace
+
+  replace="#! $(which node)" \
+    && sed -i "s|${regex}|${replace}|" "${path}"
+}
+
 function main {
   local ephemeral
   local registry_address='127.0.0.1'
@@ -40,6 +49,8 @@ function main {
                   && bin="${bins[$index]}" \
                   && bin_location="${bin_locations[$index]}" \
                   && bin_location="$(dirname "${package_json}")/${bin_location}" \
+                  && chmod +x "${bin_location}" \
+                  && patch_shebang "${bin_location}" \
                   && rm -rf "${out}/.bin/${bin}" \
                   && ln -s "${bin_location}" "${out}/.bin/${bin}" \
                   || return 1

--- a/src/args/make-node-js-modules/default.nix
+++ b/src/args/make-node-js-modules/default.nix
@@ -86,8 +86,10 @@ makeDerivation {
     bin = [
       __nixpkgs__.bash
       __nixpkgs__.findutils
+      __nixpkgs__.gnused
       __nixpkgs__.jq
       __nixpkgs__.python39
+      __nixpkgs__.which
       nodeJs
     ];
     source = [ (makeSearchPaths searchPaths) ];


### PR DESCRIPTION
- Make binaries executable as some of them
do not exist within .bin, causing permission
denied when executing symlinks
- Patch shebangs searching for node
in usr