### PR TITLE
refac(build): #494 use root address

### DIFF
--- a/src/args/make-node-js-modules/builder.sh
+++ b/src/args/make-node-js-modules/builder.sh
@@ -11,7 +11,7 @@ function patch_shebang {
 
 function main {
   local ephemeral
-  local registry_address='127.0.0.1'
+  local registry_address='0.0.0.0'
   local registry_pid
   local registry_port
 


### PR DESCRIPTION
- On MacOS, localhost and 127.0.0.1 are
  not that out-of-the-box accessible,
  so lets use 0.0.0.0 as it works very
  nice and is also the default for
  Python"s http.server library
- This means other machines in the local
  and possibly from internet network can
  access the builder if the firewall in the machine
  were open to the world, but there is
  no problem with this as the server
  only exposes read operations of information
  that is already public in the npm registry,
  an attacker would have no motivation beyond
  a DoS, which anyway is possible by other
  means if you open your firewall to the world in
  the first place