### PR TITLE
refac(build): #0 handle runtime paths

### DIFF
--- a/src/args/make-search-paths/default.nix
+++ b/src/args/make-search-paths/default.nix
@@ -28,9 +28,12 @@ let
     then "export ${envVar}=\"${envDrv}${envPath}\${${envVar}:+:}\${${envVar}:-}\""
     else "export ${envVar}=\"${envDrv}${envPath}\"";
   sourceDrv = envDrv:
-    if builtins.pathExists "${envDrv}/template"
-    then "source \"${envDrv}/template\""
-    else "source \"${envDrv}\"";
+    ''
+      if test -e "${envDrv}/template"
+      then source "${envDrv}/template"
+      else source "${envDrv}"
+      fi
+    '';
 in
 makeTemplate {
   name = "make-search-paths";


### PR DESCRIPTION
- builtins.pathExists only returns true if the path
  exists at evaluation time, which may cause trouble
  when testing paths existance on derivation outputs