### PR TITLE
feat(build): #449 ignore scripts flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2728,6 +2728,9 @@ Types:
     - searchPaths (`asIn makeSearchPaths`): Optional.
       Arguments here will be passed as-is to `makeSearchPaths`.
       Defaults to `makeSearchPaths`'s defaults.
+    - shouldIgnoreScripts (`bool`): Optional.
+      Enable to propagate the `--ignore-scripts true` flag to npm.
+      Defaults to `false`.
 
 Example:
 
@@ -2816,6 +2819,9 @@ Types:
     - searchPaths (`asIn makeSearchPaths`): Optional.
       Arguments here will be passed as-is to `makeSearchPaths`.
       Defaults to `makeSearchPaths`'s defaults.
+    - shouldIgnoreScripts (`bool`): Optional.
+      Enable to propagate the `--ignore-scripts true` flag to npm.
+      Defaults to `false`.
 
 Example:
 

--- a/src/args/make-node-js-environment/default.nix
+++ b/src/args/make-node-js-environment/default.nix
@@ -9,6 +9,7 @@
 , packageJson
 , packageLockJson
 , searchPaths ? { }
+, shouldIgnoreScripts ? false
 }:
 let
   node = makeNodeJsVersion nodeJsVersion;
@@ -18,6 +19,7 @@ let
     inherit packageJson;
     inherit packageLockJson;
     inherit searchPaths;
+    inherit shouldIgnoreScripts;
   };
 in
 makeSearchPaths {

--- a/src/args/make-node-js-modules/default.nix
+++ b/src/args/make-node-js-modules/default.nix
@@ -14,6 +14,7 @@
 , packageJson
 , packageLockJson
 , searchPaths ? { }
+, shouldIgnoreScripts ? false
 }:
 assert isLinux;
 let
@@ -91,6 +92,7 @@ makeDerivation {
     envRegistry = registry;
     envPackageJson = packageJson;
     envPackageLockJson = packageLockJson;
+    envShouldIgnoreScripts = shouldIgnoreScripts;
   };
   name = "make-node-js-modules-for-${name}";
   searchPaths = {


### PR DESCRIPTION
- Allow passing --ignore-scripts true to npm
- This allows to ignore setup scripts of dirty packages
  like imagemin/mozjpeg-bin which have side effects for
  downloading binaries from the internet which is not pure
  and whose ELFs we don't need to patch