### PR TITLE
feat(build): #553 optionally persist script state

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,6 +2,7 @@ Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalaza4@eafit.edu.co>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalazar@fluidattacks.com>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <podany270895@gmail.com>
 David Arnold <david.arnold@iohk.io> David Arnold <david.arnold@iohk.io>
+David Arnold <david.arnold@iohk.io> David Arnold <dgx.arnold@gmail.com>
 Fluid Attacks <help@fluidattacks.com> Fluid Attacks <help@fluidattacks.com>
 Github Octocat <noreply@github.com> GitHub <noreply@github.com>
 Kevin Amado <kamadorueda@gmail.com> Kevin Amado <kamadorueda@gmail.com>

--- a/README.md
+++ b/README.md
@@ -2473,6 +2473,7 @@ that runs in a **almost-isolated** environment.
   are present by default.
 - An environment variable called `STATE` points to a directory
   that can be used to store the script's state (if any).
+  That state can be optionally persisted.
 - After the build, the script is executed.
 
 Types:
@@ -2490,6 +2491,9 @@ Types:
     - searchPaths (`asIn makeSearchPaths`): Optional.
       Arguments here will be passed as-is to `makeSearchPaths`.
       Defaults to `makeSearchPaths`'s defaults.
+    - persistState (`bool`): Optional.
+      If true, state will _not_ be cleared before each script run.
+      Defaults to `false`.
 
 Example:
 

--- a/src/args/make-script/default.nix
+++ b/src/args/make-script/default.nix
@@ -13,6 +13,7 @@
 , name
 , replace ? { }
 , searchPaths ? { }
+, persistState ? false
 }:
 let
   # Minimalistic shell environment
@@ -58,6 +59,7 @@ makeDerivation {
         __argSearchPathsBase__ = searchPathsBase;
         __argSearchPathsEmpty__ = searchPathsEmpty;
         __argShell__ = "${__nixpkgs__.bash}/bin/bash";
+        __argPersistState__ = if persistState then 1 else 0;
       };
       name = "make-script-for-${name}";
       template = ./template.sh;

--- a/src/args/make-script/template.sh
+++ b/src/args/make-script/template.sh
@@ -23,7 +23,9 @@ function setup {
         && HOME="$(mktemp -d)"
     fi \
     && STATE="${HOME_IMPURE}/.makes/state/__argName__" \
-    && rm -rf "${STATE}" \
+    && if test __argPersistState__ -eq "0"; then
+      rm -rf "${STATE}"
+    fi \
     && mkdir -p "${STATE}" \
     && source __argShellCommands__ \
     && source __argSearchPaths__/template


### PR DESCRIPTION
- Add `persistState` to `makeScript` defaulting to `false`
- This default corresponds to the current behavior
- Enabling persistence should remain a mindful act
