### PR TITLE
feat(build): #553 global state across repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2491,6 +2491,7 @@ that runs in a **almost-isolated** environment.
 - An environment variable called `STATE` points to a directory
   that can be used to store the script's state (if any).
   That state can be optionally persisted.
+  That state can be optionally shared across repositories.
 - Convenience bash functions are exported:
     - `running_in_ci_cd_provider`:
         Detects if we are running on the CI/CD provider (gitlab/github/etc).
@@ -2531,6 +2532,17 @@ Types:
     - persistState (`bool`): Optional.
       If true, state will _not_ be cleared before each script run.
       Defaults to `false`.
+    - globalState (`bool`): Optional.
+      If true, script state will be written to `globalStateDir` and
+      to `projectStateDir` otherwise.
+      Defaults to `false`, if `projectStateDir` is specified or derived.
+      Note:
+        - It is implicitly `true`, if `projectStateDir == globalStateDir`.
+        - `projectStateDir == globalStateDir` is the default if
+          `projectIdentifier` is not configured.
+        - Hence, generally enable project local state by
+            - either setting `projectIdentifier`
+            - or `projectStateDir` different from `globalStateDir`.
 
 Example:
 
@@ -3780,7 +3792,10 @@ let
   makes = import "${builtins.fetchGit {
     url = "https://github.com/fluidattacks/makes";
     rev = "21.10";
-  }}/src/args/agnostic.nix";
+  }}/src/args/agnostic.nix" {
+    __globalStateDir__ = "\${HOME_IMPURE}/.makes/state";
+    __projectStateDir__ = "\${HOME_IMPURE}/.makes/state/<project-name>";
+  };
 in
 # Use the framework
 makes.makePythonPypiEnvironment {

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,12 @@
 ,
 }:
 
-with import ./src/args/agnostic.nix { inherit system; };
+with import ./src/args/agnostic.nix
+{
+  inherit system;
+  __globalStateDir__ = "/tmp/null";
+  __projectStateDir__ = "/tmp/null";
+};
 
 makeScript {
   aliases = [

--- a/makes.nix
+++ b/makes.nix
@@ -3,6 +3,7 @@
 , ...
 }:
 {
+  projectIdentifier = "makes-repo";
   cache = {
     readAndWrite = {
       enable = true;

--- a/src/args/agnostic.nix
+++ b/src/args/agnostic.nix
@@ -1,9 +1,13 @@
 # Arguments that can be used outside of a Makes project
 # and therefore are agnostic to the framework.
 { system ? builtins.currentSystem
+, __globalStateDir__
+, __projectStateDir__
 }:
 let
   args = {
+    inherit __projectStateDir__;
+    inherit __globalStateDir__;
     __nixpkgs__ = import sources.nixpkgs { inherit system; };
     __shellCommands__ = ./shell-commands/template.sh;
     __shellOptions__ = ./shell-options/template.sh;

--- a/src/args/default.nix
+++ b/src/args/default.nix
@@ -1,18 +1,26 @@
 { inputs
 , makesExecutionId
 , outputs
+, projectIdentifier
+, globalStateDir
+, projectStateDir
 , projectSrc
 , projectSrcMutable
 , system
 , ...
 }:
 let
-  agnostic = import ./agnostic.nix { inherit system; };
+  agnostic = import ./agnostic.nix {
+    inherit system;
+    __globalStateDir__ = globalStateDir;
+    __projectStateDir__ = projectStateDir;
+  };
 
   args = agnostic // {
     inherit inputs;
     inherit makesExecutionId;
     inherit outputs;
+    inherit projectIdentifier;
     inherit projectSrc;
     projectPath = import ./project-path/default.nix args;
     projectPathLsDirs = import ./project-path-ls-dirs/default.nix args;

--- a/src/args/make-script/default.nix
+++ b/src/args/make-script/default.nix
@@ -6,6 +6,8 @@
 , makeSearchPaths
 , makeTemplate
 , toDerivationName
+, __projectStateDir__
+, __globalStateDir__
 , ...
 }:
 { aliases ? [ ]
@@ -14,7 +16,9 @@
 , replace ? { }
 , searchPaths ? { }
 , persistState ? false
+, globalState ? if (__projectStateDir__ == __globalStateDir__) then true else false
 }:
+assert (if (__projectStateDir__ == __globalStateDir__) then globalState else true);
 let
   # Minimalistic shell environment
   # Let's try to keep it as lightweight as possible because this
@@ -55,11 +59,14 @@ makeDerivation {
         __argShellOptions__ = __shellOptions__;
         __argCaCert__ = __nixpkgs__.cacert;
         __argName__ = name';
+        __argProjectStateDir__ = __projectStateDir__;
+        __argGlobalStateDir__ = __globalStateDir__;
         __argSearchPaths__ = makeSearchPaths searchPaths;
         __argSearchPathsBase__ = searchPathsBase;
         __argSearchPathsEmpty__ = searchPathsEmpty;
         __argShell__ = "${__nixpkgs__.bash}/bin/bash";
         __argPersistState__ = if persistState then 1 else 0;
+        __argGlobalState__ = if globalState then 1 else 0;
       };
       name = "make-script-for-${name}";
       template = ./template.sh;

--- a/src/args/make-script/template.sh
+++ b/src/args/make-script/template.sh
@@ -36,7 +36,11 @@ function setup {
       HOME_IMPURE="${HOME:-}" \
         && HOME="$(mktemp -d)"
     fi \
-    && STATE="${HOME_IMPURE}/.makes/state/__argName__" \
+    && if test __argGlobalState__ -eq "0"; then
+      STATE="__argProjectStateDir__/__argName__"
+    else
+      STATE="__argGlobalStateDir__/__argName__"
+    fi \
     && if test __argPersistState__ -eq "0"; then
       rm -rf "${STATE}"
     fi \

--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -48,6 +48,9 @@ let
     inputs = flakeInputs // result.config.inputs;
     inherit makesExecutionId;
     outputs = result.config.outputs;
+    projectIdentifier = result.config.projectIdentifier;
+    globalStateDir = result.config.globalStateDir;
+    projectStateDir = result.config.projectStateDir;
     inherit projectSrc;
     inherit projectSrcMutable;
     inherit system;

--- a/src/evaluator/modules/default.nix
+++ b/src/evaluator/modules/default.nix
@@ -42,6 +42,20 @@
     (import ./test-terraform/default.nix args)
   ];
   options = {
+    globalStateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "\${HOME_IMPURE}/.makes/state";
+      apply = lib.removeSuffix "/"; # canonicalize
+    };
+    projectStateDir = lib.mkOption {
+      type = lib.types.str;
+      default = config.globalStateDir + "/" + config.projectIdentifier;
+      apply = lib.removeSuffix "/"; # canonicalize
+    };
+    projectIdentifier = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+    };
     attrs = lib.mkOption {
       type = lib.types.package;
     };


### PR DESCRIPTION
- Introduces `projectIdentifier`, `globalStateDir` & `projectStateDir`
- `globalStateDir` defaults to `${HOME_IMPURE}/.makes/state` (as is)
- `projectStateDir` defaults to `globalStateDir` if `projectIdentifier`
  is not specified. Makes all state effectively global.
- Both, `globalStateDir` & `projectStateDir` can also be manually set.
- In that case, `projectIdentifier` is not used for project state.
- `projectIdentifier` is independently useful in future, e.g. for
  logging.

---

#### Tested:

```diff
# no diff
```
-> `nix run . -- . /lintGitMailMap`
```console
❯ tree ~/.makes/state
/home/blaggacao/.makes/state
└── makes-repo
    └── lint-git-mailmap-for-lint-git-mailmap
```
-> `rm -rf ~/.makes/state/makes-repo`

---

```diff
diff --git a/makes.nix b/makes.nix
index 9cfe124..da5ddd6 100644
--- a/makes.nix
+++ b/makes.nix
@@ -3,7 +3,7 @@
 , ...
 }:
 {
-  projectIdentifier = "makes-repo";
+  # projectIdentifier = "makes-repo";
   cache = {
     readAndWrite = {
       enable = true;

```
-> `nix run . -- . /lintGitMailMap`
```console
❯ tree ~/.makes/state
/home/blaggacao/.makes/state
└── lint-git-mailmap-for-lint-git-mailmap
```
-> `rm -rf ~/.makes/state/lint-git-mailmap-for-lint-git-mailmap`

---

```diff
diff --git a/src/args/lint-git-mailmap/default.nix b/src/args/lint-git-mailmap/default.nix
index 02e33b9..7ede63f 100644
--- a/src/args/lint-git-mailmap/default.nix
+++ b/src/args/lint-git-mailmap/default.nix
@@ -16,6 +16,7 @@ let
 in
 makeScript {
   entrypoint = ./entrypoint.sh;
+  globalState = true;
   replace = {
     __argSrc__ = src;
   };

```
-> `nix run . -- . /lintGitMailMap`
```console
❯ tree ~/.makes/state
/home/blaggacao/.makes/state
└── lint-git-mailmap-for-lint-git-mailmap
```
-> `rm -rf ~/.makes/state/lint-git-mailmap-for-lint-git-mailmap`

---

closes: #553 