### PR TITLE
fix(build): #546 infinite recursion on `inputs.self`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,14 +31,16 @@
           };
           evaluatedOutputs = nixpkgs.lib.mapAttrs'
             (output: value: {
-              name = "makes:config:outputs:${output}";
+              name = "config:outputs:${output}";
               inherit value;
             })
             evaluated.config.outputs;
         in
-        evaluatedOutputs // {
-          "makes:config:attrs" = evaluated.config.attrs;
-          "makes:config:cacheAsJson" = evaluated.config.cacheAsJson;
+        {
+          __makes__ = evaluatedOutputs // {
+            "config:attrs" = evaluated.config.attrs;
+            "config:cacheAsJson" = evaluated.config.cacheAsJson;
+          };
         };
     };
 }

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -215,7 +215,7 @@ def _get_attrs(src: str, head: str) -> List[str]:
         args=_nix_build(
             attr="config.attrs"
             if NIX_STABLE
-            else f'{head}#"makes:config:attrs"',
+            else f'{head}#__makes__."config:attrs"',
             cache=None,
             head=head,
             out=out,
@@ -235,7 +235,7 @@ def _get_cache(src: str, head: str) -> List[Dict[str, str]]:
         args=_nix_build(
             attr="config.cacheAsJson"
             if NIX_STABLE
-            else f'{head}#"makes:config:cacheAsJson"',
+            else f'{head}#__makes__."config:cacheAsJson"',
             cache=None,
             head=head,
             out=out,
@@ -346,7 +346,7 @@ def cli(args: List[str]) -> None:
         args=_nix_build(
             attr=f'config.outputs."{attr}"'
             if NIX_STABLE
-            else f'{head}#makes:config:outputs:"{attr}"',
+            else f'{head}#__makes__."config:outputs:{attr}"',
             cache=cache,
             head=head,
             out=out,


### PR DESCRIPTION
- Assignments involving `self` are only allowed on the right hand side
  of an output. `evaluatedOutputs` violated this axiom.
- The reason lies within the recursiveness of these two lines in the
  builtin flake eval:

https://github.com/NixOS/nix/blob/7c90552879da4d1df99b50c85e94201981e60123/src/libexpr/flake/call-flake.nix#L44-L46

fixes: #573
