### PR TITLE
fix projectPath string context flakes

### DIFF
--- a/src/args/project-path/default.nix
+++ b/src/args/project-path/default.nix
@@ -7,6 +7,6 @@ if hasPrefix "/" rel
 then
   (builtins.path {
     name = if rel == "/" then "src" else builtins.baseNameOf rel;
-    path = projectSrc + rel;
+    path = ((builtins.unsafeDiscardStringContext projectSrc) + rel);
   })
 else abort "projectPath arguments must start with: /, currently it is: ${rel}"


### PR DESCRIPTION
- `self.sourceInfo.outPath` brings a string context with it
- Drop it for this pattern to work
- Idempotent noop in non-flake scenario

fixes: #577 (has more context)

---

Appreciation to the really helpful support on matrix from

- abathur
- symphorien
- dee
