### PR TITLE
fix(build): #546 makes' inputs topple flakes'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
         }:
         let
           evaluated = import ./src/evaluator/default.nix {
-            extraInputs = inputs;
+            flakeInputs = inputs;
             # TODO: Deprecate this
             makesExecutionId = "123";
             makesSrc = inputs.makes.outPath;

--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -10,8 +10,8 @@
 # You better avoid changing this function signature...
 # Ask a maintainer first.
 {
-  # extra inputs to inject, if any
-  extraInputs ? { }
+  # flake inputs to inject, if any
+  flakeInputs ? { }
   # Unique ID for this execution of makes
 , makesExecutionId
   # Source code of makes, can be overriden by the user.
@@ -45,7 +45,7 @@ let
     else makesSrc;
 
   args = import "${makesSrcOverriden}/src/args/default.nix" {
-    inputs = result.config.inputs // extraInputs;
+    inputs = flakeInputs // result.config.inputs;
     inherit makesExecutionId;
     outputs = result.config.outputs;
     inherit projectSrc;


### PR DESCRIPTION
- Make inputs now prime over flake inputs
- Rename to reflect this special purpose (& temporary) semantics of
  this arg

fixes: #579
