### PR TITLE
feat(build): #521 standard for derivation help

### DIFF
--- a/makes/tests/scriptWithHelp/README.md
+++ b/makes/tests/scriptWithHelp/README.md
@@ -1,0 +1,7 @@
+# A Script With a Help
+
+- This is `makes/tests/scriptWithHelp/README.md`
+- You might be looking at it beautifully rendered on GitHub / GitLab / etc.
+- You also might be looking at it beautifully rendedred on the CLI\*.
+
+\* `m . /tests/scriptWithHelp -h` (or `--help`)

--- a/makes/tests/scriptWithHelp/main.nix
+++ b/makes/tests/scriptWithHelp/main.nix
@@ -1,0 +1,8 @@
+{ makeScript
+, ...
+}:
+makeScript {
+  entrypoint = "echo A script with a help, call with --help or -h to see it!";
+  name = "help";
+  help = ./README.md;
+}

--- a/src/args/agnostic.nix
+++ b/src/args/agnostic.nix
@@ -39,6 +39,7 @@ let
     fromYamlFile = path: args.fromYaml (builtins.readFile path);
     gitlabCi = import ./gitlab-ci/default.nix;
     hasPrefix = lib.strings.hasPrefix;
+    hasSuffix = lib.strings.hasSuffix;
     isDarwin = args.__nixpkgs__.stdenv.isDarwin;
     isLinux = args.__nixpkgs__.stdenv.isLinux;
     listOptional = lib.lists.optional;

--- a/src/args/make-derivation/default.nix
+++ b/src/args/make-derivation/default.nix
@@ -4,6 +4,7 @@
 , __system__
 , asContent
 , hasPrefix
+, hasSuffix
 , makeSearchPaths
 , attrsOptional
 , toDerivationName
@@ -16,6 +17,7 @@
 , envFiles ? { }
 , local ? false
 , name
+, help ? null
 , searchPaths ? { }
 , sha256 ? null
 }:
@@ -34,9 +36,31 @@ let
     ))
     (env // envFiles);
 
+  # Validate that help is a Markdown file
+  help' =
+    if (help == null) then help else
+    if (hasSuffix ".md" help)
+      || (hasSuffix ".MD" help)
+      || (hasSuffix ".Md" help)
+      || (hasSuffix ".mD" help)
+    then help
+    else
+      abort ''
+
+          Invalid help file: ${toString help}, must be a markdown file
+
+        '';
+
   searchPathsBase = __nixpkgs__.lib.strings.makeBinPath [
     __nixpkgs__.coreutils
   ];
+
+  searchPathsAction = __nixpkgs__.lib.strings.makeBinPath [
+    __nixpkgs__.coreutils
+    __nixpkgs__.less
+    __nixpkgs__.glow
+  ];
+
 in
 builtins.derivation (env' // {
   __envShellCommands = __shellCommands__;
@@ -56,6 +80,10 @@ builtins.derivation (env' // {
       if test -v __envAction; then
         copy $__envAction $out/makes-action.sh
       fi
+
+      if test -v __envHelp; then
+        copy $__envHelp $out/README.md
+      fi
     '')
   ];
   builder = "${__nixpkgs__.bash}/bin/bash";
@@ -66,10 +94,30 @@ builtins.derivation (env' // {
 } // attrsOptional (action != null) {
   __envAction = __nixpkgs__.writeShellScript "makes-action-for-${name}" ''
     source ${__shellOptions__}
-    export PATH=${searchPathsBase}
+    export PATH=${searchPathsAction}
+
+    scriptName="$1"
+    shift 1
+
+    if test -f ''${BASH_SOURCE%/*}/README.md; then
+      case $1 in
+        -h|--help)
+          export LESSCHARSET=utf-8
+          glow --pager --local ''${BASH_SOURCE%/*}/README.md
+          exit 0
+          ;;
+        --)
+          shift
+          ;;
+      esac
+    fi
+
+    set -- "$scriptName" "$@"
 
     ${action}
   '';
+} // attrsOptional (help' != null) {
+  __envHelp = help';
 } // attrsOptional (local) {
   allowSubstitutes = false;
   preferLocalBuild = true;

--- a/src/args/make-script-parallel/default.nix
+++ b/src/args/make-script-parallel/default.nix
@@ -6,6 +6,7 @@
 { commands
 , extraArgs ? [ ]
 , name
+, help ? null
 }:
 makeScript {
   replace = {
@@ -13,6 +14,7 @@ makeScript {
     __argParallelArgs__ = toBashArray extraArgs;
   };
   entrypoint = ./entrypoint.sh;
+  inherit help;
   name = "make-script-parallel-for-${name}";
   searchPaths = {
     bin = [

--- a/src/args/make-script/default.nix
+++ b/src/args/make-script/default.nix
@@ -13,6 +13,7 @@
 { aliases ? [ ]
 , entrypoint
 , name
+, help ? null
 , replace ? { }
 , searchPaths ? { }
 , persistState ? false
@@ -74,5 +75,5 @@ makeDerivation {
   };
   builder = ./builder.sh;
   local = true;
-  inherit name;
+  inherit name help;
 }

--- a/src/args/make-template/default.nix
+++ b/src/args/make-template/default.nix
@@ -8,6 +8,7 @@
 
 { local ? true
 , name
+, help ? null
 , replace ? { }
 , replaceBase64 ? { }
 , searchPaths ? { }
@@ -57,6 +58,6 @@ makeDerivation {
       '';
   };
   builder = ./builder.sh;
-  inherit local;
+  inherit local help;
   name = "make-template-for-${name}";
 }


### PR DESCRIPTION
- Enable derivations to contain help as markdown
- Show help on all actions with `--help | -h` if help is set
- Show that help with `glow`

Why Markdown:

- needs to look good on github and cli
- github cli uses glow's library for `gh repo info`
- glow's library is md only
- among markup languages, md is the best known and most familiar one


---

- This is probably a good enough platform to venture into the frontmatter aspects as discussed in https://github.com/fluidattacks/makes/issues/521#issuecomment-922387563 ff. 
- Docs tbd after design accepted
- change `glow` for https://kristaps.bsd.lv/lowdown/ (used by `nix`)