### PR TITLE
refac(build): #598 run scripts on cwd

### DIFF
--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -425,7 +425,6 @@ def execute_action(args: List[str], head: str, out: str, src: str) -> None:
         code, _, _ = _run(
             args=[action_path, out, *args],
             capture_io=False,
-            cwd=src if is_src_local(src) else head,
         )
         raise SystemExit(code)
 


### PR DESCRIPTION
- It makes sense to run scripts on CWD instead
  of SRC or HEAD, this is because as a user I would
  like to run apps offered by a Makes project
  anywhere in my file system. For instance if
  someone offered a jpg to png binary, I
  would like to do `m github:... /jpg2png ./x ./y`
  instead of having to use full paths,
  or relative paths to a temporary folder,
  which cause cryptic behavior