### PR TITLE
refac(build): #598 run scripts on cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Real life projects that run entirely on [Makes][MAKES]:
 - [Why](#why)
 - [Goal](#goal)
 - [Getting started](#getting-started)
-    - [Getting started as user](#getting-started-as-user)
+    - [Getting started as a final user](#getting-started-as-a-final-user)
     - [Getting started as developer](#getting-started-as-developer)
     - [Learning the language](#learning-the-language)
     - [Versioning scheme for the framework](#versioning-scheme-for-the-framework)
@@ -398,17 +398,9 @@ Makes targets two kind of users:
 - Final users: People that want to use projects built with Makes.
 - Developers: People who develop projects with Makes.
 
-## Getting started as user
+## Getting started as a final user
 
 1. List outputs of a [Makes] project:
-
-    - For local [Makes][MAKES] projects, run:
-
-      `$ m /path/to/local/repository`
-
-      or if the project is in the current working directory, run:
-
-      `$ m .`
 
     - For GitHub [Makes][MAKES] projects, run:
 
@@ -448,7 +440,7 @@ Makes targets two kind of users:
     that you can include in jour project as simple as this.
 
 1. Now run makes!
-    - List all available commands: `$ m .`
+    - List all available outputs: `$ m .`
 
         ```
         Outputs list for project: /path/to/my/project
@@ -2069,7 +2061,7 @@ In order to do this:
 
 1. Now run makes!
 
-    - List all available commands: `$ m .`
+    - List all available outputs: `$ m .`
 
         ```
         Outputs list for project: /path/to/my/project

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -15,7 +15,6 @@ from os import (
 from os.path import (
     exists,
     getctime,
-    isdir,
     join,
 )
 from posixpath import (
@@ -178,7 +177,7 @@ def _clone_src_cache_refresh(head: str, cache_key: str) -> None:
 
 
 def is_src_local(src: str) -> bool:
-    return isdir(src)
+    return abspath(src) == CWD
 
 
 def _nix_build(
@@ -340,16 +339,14 @@ def _help_and_exit(
         _log()
         _log("[SOURCE] can be:")
         _log()
-        _log("  A local Git repository:")
-        _log("    /path/to/local/repository")
-        _log("    ./relative/path")
-        _log("    .")
+        _log("  A Git repository in the current working directory:")
+        _log("    $ m .")
         _log()
         _log("  A GitHub repository and revision (branch, commit or tag):")
-        _log("    github:owner/repo@rev")
+        _log("    $ m github:owner/repo@rev")
         _log()
         _log("  A GitLab repository and revision (branch, commit or tag):")
-        _log("    gitlab:owner/repo@rev")
+        _log("    $ m gitlab:owner/repo@rev")
     if attrs is None:
         _log()
         _log("[OUTPUT] options will be listed when you provide a [SOURCE]")
@@ -413,19 +410,19 @@ def cli(args: List[str]) -> None:
 
     if code == 0:
         cache_push(cache, out)
-        execute_action(args, head, out, src)
+        execute_action(args, out)
 
     raise SystemExit(code)
 
 
-def execute_action(args: List[str], head: str, out: str, src: str) -> None:
+def execute_action(args: List[str], out: str) -> None:
     action_path: str = join(out, "makes-action.sh")
 
     if exists(action_path):
         code, _, _ = _run(
             args=[action_path, out, *args],
             capture_io=False,
-            cwd=src if is_src_local(src) else head,
+            cwd=CWD,
         )
         raise SystemExit(code)
 


### PR DESCRIPTION
- This allows us to remove projectPathMutable,
  see why
- When running a remote project, it makes
  sense to be able to run it from anywhere in the
  file system, and therefore CWD is the intuitive choice.
  This allows the following use case:
  someone offer a jpg to png binary,
  users of such project can run it like this:
  `m github:... /jpg2png ./x ../y`, where
  x and y are relative to its current location.
- The option to run projects located in other
  places than the current folder has been removed.
  it's counter-intuitive, and it introduces the need
  for a projectPathMutable, which is not available
  on future releases of nix
- When running a project in the current working
  directory, it's because with all probability I'm a dev
  and I want to format my code, run some tests, or test
  binaries out, therefore CWD is also intuitive