### PR TITLE
refac(cross): #0 bump to 21.11

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -27,15 +27,15 @@ jobs:
     - uses: actions/checkout@v2
     - uses: richardsimko/update-tag@v1
       with:
-        tag_name: "21.10"
+        tag_name: "21.11"
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - uses: johnwbyrd/update-release@v1.0.0
       with:
         files: README.md
-        release: "21.10"
+        release: "21.11"
         prerelease: true
-        tag: "21.10"
+        tag: "21.11"
         token: ${{ github.token }}
 name: prod
 on:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Makes v21.10
+# Makes v21.11
 
 A DevSecOps framework
 powered by [Nix][NIX].
@@ -65,7 +65,7 @@ Easy, isn't it?
 Now 🔥 it up with: `$ m . /deployTerraform/myAwesomeMicroService`
 
 ```text
-Makes v21.10-linux
+Makes v21.11-linux
 
 [INFO] Making environment variables for Terraform for myAwesomeMicroService:
 [INFO] - TF_VAR_githubToken from GITHUB_API_TOKEN
@@ -109,7 +109,7 @@ spec:
     spec:
       containers:
         - name: example
-          image: ghcr.io/fluidattacks/makes:21.10
+          image: ghcr.io/fluidattacks/makes:21.11
           command: [m]
           args:
             - github:fluidattacks/makes@main
@@ -448,14 +448,14 @@ In order to use Makes you'll need to:
 
     - For Nix versions >= 2.3 and < 2.4 (nix stable)
 
-      `$ nix-env -if https://fluidattacks.com/makes/install/21.10`
+      `$ nix-env -if https://fluidattacks.com/makes/install/21.11`
 
     - For Nix versions == 2.4 (nix unstable)
 
-      `$ nix profile install github:fluidattacks/makes/21.10`
+      `$ nix profile install github:fluidattacks/makes/21.11`
 
     We will install two commands in your system:
-    `$ m`, and `$ m-v21.10`.
+    `$ m`, and `$ m-v21.11`.
 
 Makes targets two kind of users:
 
@@ -558,7 +558,7 @@ for instance:
 {
   makesSrc = builtins.fetchGit {
     url = "https://github.com/fluidattacks/makes";
-    ref = "21.10";
+    ref = "21.11";
   };
 }
 ```
@@ -568,7 +568,7 @@ for instance:
 For the whole ecosystem to work
 you need to use the **same version**
 of the framework and the CLI.
-For example: `21.10`.
+For example: `21.11`.
 
 ## Command-line completion
 
@@ -628,7 +628,7 @@ jobs:
     - uses: actions/checkout@v2
       # We offer this GitHub action in the following versions:
       #   main: latest release (example: /makes:main)
-      #   yy.mm: monthly release (example: /makes:21.10)
+      #   yy.mm: monthly release (example: /makes:21.11)
     - uses: docker://ghcr.io/fluidattacks/makes:main
       # You can use any name you like here
       name: helloWorld
@@ -655,7 +655,7 @@ looks like this:
 /helloWorld:
   # We offer this Container Image in the following tags:
   #   main: latest release (example: /makes:main)
-  #   yy.mm: monthly release (example: /makes:21.10)
+  #   yy.mm: monthly release (example: /makes:21.11)
   image: ghcr.io/fluidattacks/makes:main
   script:
     - m . /helloWorld 1 2 3
@@ -683,8 +683,8 @@ language: nix
 nix: 2.3.12
 # We offer this installation step in the following versions:
 #   main: latest release (example: /install/main)
-#   yy.mm: monthly release (example: /install/21.10)
-install: nix-env -if https://fluidattacks.com/makes/install/21.10
+#   yy.mm: monthly release (example: /install/21.11)
+install: nix-env -if https://fluidattacks.com/makes/install/21.11
 env:
   global:
     # Encrypted environment variable
@@ -1572,7 +1572,7 @@ Types:
           #
           # If you need to run jobs on different container images,
           # simply  create many `aws_batch_job_definition`s
-          image = "ghcr.io/fluidattacks/makes:21.10"
+          image = "ghcr.io/fluidattacks/makes:21.11"
 
           # Below arguments can be parametrized later,
           # but they are required for the job definition to be created
@@ -3576,7 +3576,7 @@ Pre-requisites:
 1. You need to generate `sourcesYaml` like this:
 
     ```bash
-    m github:fluidattacks/makes@21.10 /utils/makePythonPypiEnvironmentSources \
+    m github:fluidattacks/makes@21.11 /utils/makePythonPypiEnvironmentSources \
       "${python_version}" \
       "${dependencies_yaml}" \
       "${sources_yaml}
@@ -3664,7 +3664,7 @@ $ cat /path/to/my/project/makes/example/dependencies.yaml
 
   Django: "3.2.6"
 
-$ m github:fluidattacks/makes@21.10 /utils/makePythonPypiEnvironmentSources \
+$ m github:fluidattacks/makes@21.11 /utils/makePythonPypiEnvironmentSources \
     3.8 \
     /path/to/my/project/makes/example/dependencies.yaml \
     /path/to/my/project/makes/example/sources.yaml
@@ -4495,7 +4495,7 @@ let
   # Import the framework
   makes = import "${builtins.fetchGit {
     url = "https://github.com/fluidattacks/makes";
-    rev = "21.10";
+    rev = "21.11";
   }}/src/args/agnostic.nix" { };
 in
 # Use the framework

--- a/default.nix
+++ b/default.nix
@@ -7,9 +7,9 @@ with import ./src/args/agnostic.nix { inherit system; };
 let
   bin = makeScript {
     aliases = [
-      "m-v21.10"
+      "m-v21.11"
       "makes"
-      "makes-v21.10"
+      "makes-v21.11"
     ];
     replace = {
       __argMakesSrc__ = ./.;

--- a/makes.nix
+++ b/makes.nix
@@ -23,7 +23,7 @@
         attempts = 3;
         registry = "ghcr.io";
         src = outputs."/container-image";
-        tag = "fluidattacks/makes:21.10";
+        tag = "fluidattacks/makes:21.11";
       };
     };
   };

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -51,7 +51,7 @@ OUT_BASE: str = tempfile.mkdtemp()
 ON_EXIT: List[Callable[[], None]] = [
     partial(shutil.rmtree, OUT_BASE, ignore_errors=True)
 ]
-VERSION: str = "21.10"
+VERSION: str = "21.11"
 
 # Environment
 __MAKES_REGISTRY__: str = environ["__MAKES_REGISTRY__"]

--- a/src/evaluator/modules/pipelines/default.nix
+++ b/src/evaluator/modules/pipelines/default.nix
@@ -81,7 +81,7 @@ let
     value = attrsMerge [
       gitlabExtra
       ({
-        image = "ghcr.io/fluidattacks/makes:21.10";
+        image = "ghcr.io/fluidattacks/makes:21.11";
         interruptible = true;
         needs = [ ];
         script =


### PR DESCRIPTION
- Now 21.10 becomes the stable release,
  the version people should use on their production systems
- 21.11 becomes the unstable release,
  an alias to `main`,
  where we push changes daily
  and in backward incompatible ways when needed
- Thank you so much to the people that contributed
  in different ways to make this release possible:
  issues, feature requests, feedback, using it, github stars,
  and special thanks to the people that contributed code
  so other people around the world could use it.

  I firmly believe that we achieve more together!