### PR TITLE
feat(build): #524 add javascript formatter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,6 +3,8 @@ Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalazar@fluidattacks.co
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <podany270895@gmail.com>
 David Arnold <david.arnold@iohk.io> David Arnold <david.arnold@iohk.io>
 David Arnold <david.arnold@iohk.io> David Arnold <dgx.arnold@gmail.com>
+Diego Restrepo <drestrepo@fluidattacks.com> Diego Restrepo Mesa <36453706+drestrepom@users.noreply.github.com>
+Diego Restrepo <restrepomesadiego@gmail.com> Diego Restrepo Mesa <36453706+drestrepom@users.noreply.github.com>
 Fluid Attacks <help@fluidattacks.com> Fluid Attacks <help@fluidattacks.com>
 Github Octocat <noreply@github.com> GitHub <noreply@github.com>
 Kevin Amado <kamadorueda@gmail.com> Kevin Amado <kamadorueda@gmail.com>

--- a/makes.nix
+++ b/makes.nix
@@ -53,6 +53,10 @@
     enable = true;
     targets = [ "/" ];
   };
+  formatJavaScript = {
+    enable = true;
+    targets = [ "/" ];
+  };
   formatMarkdown = {
     enable = true;
     doctocArgs = [ "--title" "# Contents" ];

--- a/src/evaluator/modules/default.nix
+++ b/src/evaluator/modules/default.nix
@@ -19,6 +19,7 @@
     (import ./format-markdown/default.nix args)
     (import ./format-nix/default.nix args)
     (import ./format-python/default.nix args)
+    (import ./format-javascript/default.nix args)
     (import ./format-terraform/default.nix args)
     (import ./hello-world/default.nix args)
     (import ./inputs/default.nix)

--- a/src/evaluator/modules/format-javascript/default.nix
+++ b/src/evaluator/modules/format-javascript/default.nix
@@ -1,0 +1,41 @@
+{ __nixpkgs__
+, toBashArray
+, makeScript
+, ...
+}:
+{ config
+, lib
+, ...
+}: {
+  options = {
+    formatJavaScript = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+      };
+      targets = lib.mkOption {
+        default = [ "/" ];
+        type = lib.types.listOf lib.types.str;
+      };
+    };
+  };
+  config = {
+    outputs = {
+      "/formatJavaScript" = lib.mkIf config.formatJavaScript.enable
+        (makeScript {
+          replace = {
+            __argSettingsPrettier__ = ./settings-prettierrc.yaml;
+            __argTargets__ = toBashArray
+              (builtins.map (rel: "." + rel) config.formatJavaScript.targets);
+          };
+          name = "format-javascript";
+          searchPaths = {
+            bin = [
+              __nixpkgs__.nodePackages.prettier
+            ];
+          };
+          entrypoint = ./entrypoint.sh;
+        });
+    };
+  };
+}

--- a/src/evaluator/modules/format-javascript/entrypoint.sh
+++ b/src/evaluator/modules/format-javascript/entrypoint.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+
+function main {
+  local args_prettier=(
+    --config '__argSettingsPrettier__'
+  )
+  source __argTargets__/template local targets
+
+  if running_in_ci_cd_provider; then
+    args_prettier+=(--check)
+  else
+    args_prettier+=(--write)
+  fi \
+    && for target in "${targets[@]}"; do
+      prettier "${args_prettier[@]}" "${target}"
+    done
+}
+
+main "${@}"

--- a/src/evaluator/modules/format-javascript/settings-prettierrc.yaml
+++ b/src/evaluator/modules/format-javascript/settings-prettierrc.yaml
@@ -1,0 +1,7 @@
+useTabs: false
+semi: true
+trailingComma: "es5"
+singleQuote: false
+tabWidth: 2
+bracketSpacing: true
+arrowParens: always


### PR DESCRIPTION
use pettier to format code, pettier allows to format the following languages

- JavaScript
- JSX
- Angular
- Vue
- Flow
- TypeScript
- CSS, Less, and SCSS
- HTML
- JSON
- GraphQL
- Markdown
- YAML