### PR TITLE
refac(build): #0 dont delete dot git

### DIFF
--- a/src/args/project-path/default.nix
+++ b/src/args/project-path/default.nix
@@ -6,6 +6,10 @@ rel:
 if hasPrefix "/" rel
 then
   (builtins.path {
+    filter = path: type:
+      if rel == "/"
+      then type != "directory" || builtins.baseNameOf path != ".git"
+      else true;
     name = if rel == "/" then "src" else builtins.baseNameOf rel;
     path = ((builtins.unsafeDiscardStringContext projectSrc) + rel);
   })

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -271,7 +271,6 @@ def _get_head(src: str) -> str:
             else:
                 remove(dest)
 
-    shutil.rmtree(join(head, ".git"))
     return head
 
 


### PR DESCRIPTION
- Dont delete the dot git folder when copying the
  project into a temporary location
- Make projectPath exclude the .git folder when
  dumping paths
- No reproducibility sacrifices would exist because
  nar serializations of projectPath before and after
  this change will be the same. So for derivations
  no changes apply.
- The change is for makeScript-based operations,
  since now they have access to the repository history,
  which makes knowing things like the git branch, or the
  git commit possible. Simplifying deployment to other
  platforms than local