### PR TITLE
refac(build): #648 not copy on unstable

### DIFF
--- a/makes.nix
+++ b/makes.nix
@@ -118,7 +118,7 @@
     {
       dirsOfModules = {
         makes = {
-          python = "3.8";
+          python = "3.9";
           inherit searchPaths;
           src = "/src/cli";
         };
@@ -131,7 +131,7 @@
       };
       modules = {
         cliMain = {
-          python = "3.8";
+          python = "3.9";
           inherit searchPaths;
           src = "/src/cli/main";
         };
@@ -202,7 +202,7 @@
   };
   securePythonWithBandit = {
     cli = {
-      python = "3.8";
+      python = "3.9";
       target = "/src/cli";
     };
   };


### PR DESCRIPTION
- Avoid copying the repo when doing `$ m .`
  on Nix unstable. Nix already ensures
  the project will be evaluated with data
  from a pristine git checkout
- Propagate env so vars like PATH
  are seen by the syscall