### PR TITLE
feat(back): #753.1 add scala formatter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -8,6 +8,7 @@ Diego Restrepo <restrepomesadiego@gmail.com> Diego Restrepo Mesa <36453706+drest
 Fluid Attacks <help@fluidattacks.com> Fluid Attacks <help@fluidattacks.com>
 Github Dependabot <49699333+dependabot[bot]@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Github Octocat <noreply@github.com> GitHub <noreply@github.com>
+John Perez <jperez@fluidattacks.com> John Perez <34050007+jpverde@users.noreply.github.com>
 Kevin Amado <kamadorueda@gmail.com> Kevin Amado <kamadorueda@gmail.com>
 Luis Saavedra <lsaavedra@fluidattacks.com> Luis David Saavedra <40694133+ludsrill@users.noreply.github.com>
 Luis Saavedra <lsaavedra@fluidattacks.com> Luis Saavedra <lsaavedra@fluidattacks.com>

--- a/src/evaluator/modules/default.nix
+++ b/src/evaluator/modules/default.nix
@@ -21,6 +21,7 @@
     (import ./format-markdown/default.nix args)
     (import ./format-nix/default.nix args)
     (import ./format-python/default.nix args)
+    (import ./format-scala/default.nix args)
     (import ./format-javascript/default.nix args)
     (import ./format-terraform/default.nix args)
     (import ./hello-world/default.nix args)

--- a/src/evaluator/modules/format-scala/default.nix
+++ b/src/evaluator/modules/format-scala/default.nix
@@ -1,0 +1,53 @@
+{ __nixpkgs__
+, toBashArray
+, makeDerivation
+, makeScript
+, isDarwin
+, fetchUrl
+, ...
+}:
+{ config
+, lib
+, ...
+}:
+let
+  chmodX = name: envSrc: makeDerivation {
+    env = { inherit envSrc; };
+    builder = "cp $envSrc $out && chmod +x $out";
+    inherit name;
+  };
+  scalafmt_version = "3.0.8";
+  binary_name = if isDarwin then "scalafmt-macos" else "scalafmt-linux-musl";
+  binary_file = fetchUrl {
+    url = "https://github.com/scalameta/scalafmt/releases/download/v${scalafmt_version}/${binary_name}";
+    sha256 = "0nxpny86qdbgsmxc9qzsv8f5qb21y25iyr8h2wg61kgiaw8988g0";
+  };
+in
+{
+  options = {
+    formatScala = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+      };
+      targets = lib.mkOption {
+        default = [ "/" ];
+        type = lib.types.listOf lib.types.str;
+      };
+    };
+  };
+  config = {
+    outputs = {
+      "/formatScala" = lib.mkIf config.formatScala.enable
+        (makeScript {
+          replace = {
+            __argTargets__ = toBashArray
+              (builtins.map (rel: "." + rel) config.formatJavaScript.targets);
+            __argScalaFmtBinary__ = chmodX "scalafmt" binary_file;
+          };
+          name = "format-scala";
+          entrypoint = ./entrypoint.sh;
+        });
+    };
+  };
+}

--- a/src/evaluator/modules/format-scala/entrypoint.sh
+++ b/src/evaluator/modules/format-scala/entrypoint.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=bash
+
+function main {
+  source __argTargets__/template local targets
+
+  for target in "${targets[@]}"; do
+    '__argScalaFmtBinary__' "${target}"
+  done
+}
+
+main "${@}"


### PR DESCRIPTION
- i decided not to use `nixpkgs.scalafmt` because it uses an old version (v2.6.4)
- `nixpkgs.scalafmt` compiles on site, this makes longer dependencies
- i download the binary and `java-jdk` is not required