### PR TITLE
feat(build): #683 add kill port

### DIFF
--- a/src/args/agnostic.nix
+++ b/src/args/agnostic.nix
@@ -48,6 +48,7 @@ let
     hasSuffix = lib.strings.hasSuffix;
     isDarwin = args.__nixpkgs__.stdenv.isDarwin;
     isLinux = args.__nixpkgs__.stdenv.isLinux;
+    killPort = import ./kill-port/default.nix args;
     libGit = import ./lib-git/default.nix args;
     listOptional = lib.lists.optional;
     lintClojure = import ./lint-clojure/default.nix args;

--- a/src/args/kill-port/main.nix
+++ b/src/args/kill-port/main.nix
@@ -1,0 +1,13 @@
+{ __nixpkgs__
+, makeTemplate
+, ...
+}:
+makeTemplate {
+  name = "kill-port";
+  searchPaths = {
+    bin = [
+      __nixpkgs__.lsof
+    ];
+  };
+  template = ./template.sh;
+}

--- a/src/args/kill-port/template.sh
+++ b/src/args/kill-port/template.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=bash
+
+function kill_port {
+  local pids
+  local port="${1}"
+
+  pids="$(mktemp)" \
+    && if ! lsof -t "-i:${port}" > "${pids}"; then
+      info Nothing listening on port: "${port}" \
+        && return 0
+    fi \
+    && while read -r pid; do
+      if kill -9 "${pid}"; then
+        if timeout 5 tail --pid="${pid}" -f /dev/null; then
+          info "Killed pid: ${pid}, listening on port: ${port}"
+        else
+          warn "kill timeout pid: ${pid}, listening on port: ${port}"
+        fi
+      else
+        error "Unable to kill pid: ${pid}, listening on port: ${port}"
+      fi
+    done < "${pids}"
+}


### PR DESCRIPTION
- function required to kill ports when launching
  a service that uses a port and is busy