### PR TITLE
feat(build): #683 take arguments as project path

### DIFF
--- a/src/evaluator/modules/dynamodb/default.nix
+++ b/src/evaluator/modules/dynamodb/default.nix
@@ -13,10 +13,10 @@ let
       inherit name;
       inherit (args) host;
       inherit (args) port;
+      inherit (args) infra;
       inherit (args) daemonMode;
       inherit (args) dataDerivation;
-      data = builtins.map (rel: "." + rel) args.data;
-      infra = "." + args.infra;
+      inherit (args) data;
     };
   };
 in


### PR DESCRIPTION
- some arguments can be taken from places where the source
  code might not be available (ks8)
- a copy of the data is required and not a reference to the
  current location