### PR TITLE
fix(build): deployNomad namespace type

### DIFF
--- a/src/evaluator/modules/deploy-nomad/default.nix
+++ b/src/evaluator/modules/deploy-nomad/default.nix
@@ -53,7 +53,7 @@ in
               type = lib.types.str;
             };
             namespace = lib.mkOption {
-              type = lib.types.path;
+              type = lib.types.str;
             };
             version = versionOpt;
           };

--- a/src/evaluator/modules/deploy-nomad/default.nix
+++ b/src/evaluator/modules/deploy-nomad/default.nix
@@ -50,7 +50,7 @@ in
           options = {
             setup = setupOpt;
             src = lib.mkOption {
-              type = lib.types.str;
+              type = lib.types.path;
             };
             namespace = lib.mkOption {
               type = lib.types.str;


### PR DESCRIPTION
error output: 
```
A definition for option `deployNomad.jobs.job2.namespace' is not of type `path'. Definition values:                      
- In `<unknown-file>': "default" 
```
fixed output:
![image](https://user-images.githubusercontent.com/21156405/143722732-af890890-e6e2-46f5-8bf6-943170f5dcf5.png)
