### PR TITLE
perf(back): #861.1 build output

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
+Daniel Murcia <danmur97@outlook.com> Daniel F. Murcia Rivera <danmur97@outlook.com>
+Daniel Murcia <danmur97@outlook.com> Daniel Murcia <42251914+danmur97@users.noreply.github.com>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalaza4@eafit.edu.co>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalazar@fluidattacks.com>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <podany270895@gmail.com>


### PR DESCRIPTION
- do not use process.communicate on nix build call
- add _run_outputs for intensionally use process.communicate
- do not use dangerous (for the wait cmd) default PIPE values