### PR TITLE
refac(back): #894 split function

### DIFF
--- a/makes.nix
+++ b/makes.nix
@@ -44,6 +44,7 @@
       bin = [inputs.nixpkgs.hello];
     };
     makes = {
+      bin = [inputs.nixpkgs.just];
       source = [outputs."/cli/pypi"];
     };
   };


### PR DESCRIPTION
- Create a Config composite type
- Split main function into some steps
- The reason for this change is that
  we are just at the limit of the length
  of the `cli` function and I cannot add
  any more code without the linter yelling at me