### PR TITLE
feat(back): #894 use repo url

### DIFF
--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -956,8 +956,8 @@ def write_provenance(
     src_uri: str = (
         # GitLab
         (
-            f"git+https://{environ['CI_REPOSITORY_URL']}"
-            if "CI_REPOSITORY_URL" in environ
+            f"git+{environ['CI_PROJECT_URL']}"
+            if "CI_PROJECT_URL" in environ
             else ""
         )
         # GitHub


### PR DESCRIPTION
- The previous environment variable may contain a temporary user and password generated by gitlab while clonning the repository, so lets use another variable witohut it