### PR TITLE
fix(back): #909 container executions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1611,6 +1611,8 @@ Example invocation: `$ m . /testTerraform/module2`
 
 ### secureKubernetesWithRbacPolice
 
+:warning: This function is only available on Linux at the moment.
+
 Secure Kubernetes clusters with [rbac-police][rbac-police].
 
 Types:

--- a/src/args/secure-kubernetes-with-rbac-police/entrypoint.sh
+++ b/src/args/secure-kubernetes-with-rbac-police/entrypoint.sh
@@ -19,15 +19,11 @@ function evaluate {
 }
 
 function main {
-  local bin
   local output
 
   : \
-    && bin="$(mktemp)" \
-    && copy "__argBin__" "${bin}" \
-    && chmod +x "${bin}" \
     && pushd "__argRepo__" \
-    && output="$("${bin}" "eval" "lib/" -s "__argSeverity__" 2>&1)" \
+    && output="$("__argBin__" "eval" "lib/" -s "__argSeverity__" 2>&1)" \
     && popd \
     && evaluate "${output}" \
     || return 1


### PR DESCRIPTION
- Patch rbac-police binary so it uses nixpkgs glibc ld-linux
- This fixes the job on containers
- Stop supporting darwin due to the patch