### PR TITLE
fix(cross): #0 versioning scheme

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -23,15 +23,15 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - uses: richardsimko/update-tag@5bd0e05b035e02d5da3768dbdcfc4e5e0908623e
         with:
-          tag_name: '22.09'
+          tag_name: '22.10'
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: johnwbyrd/update-release@1d5ec4791e40507e5eca3b4dbf90f0b27e7e4979
         with:
           files: README.md
-          release: '22.09'
+          release: '22.10'
           prerelease: true
-          tag: '22.09'
+          tag: '22.10'
           token: ${{ github.token }}
   linux_all:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -1,6 +1,6 @@
 ---
 /helloWorld__1__2__3:
-  image: ghcr.io/fluidattacks/makes:22.09
+  image: ghcr.io/fluidattacks/makes:22.10
   interruptible: true
   needs: []
   script:
@@ -9,7 +9,7 @@
     GIT_DEPTH: 1
     MAKES_GIT_DEPTH: 1
 /lintNix:
-  image: ghcr.io/fluidattacks/makes:22.09
+  image: ghcr.io/fluidattacks/makes:22.10
   interruptible: true
   needs: []
   script:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
         - name: example
-          image: ghcr.io/fluidattacks/makes:22.09
+          image: ghcr.io/fluidattacks/makes:22.10
           command: [m]
           args:
             - github:fluidattacks/makes@main
@@ -146,7 +146,7 @@ Easy, isn't it?
 Now 🔥 it up with: `$ m . /deployTerraform/myAwesomeMicroService`
 
 ```text
-Makes v22.09-linux
+Makes v22.10-linux
 
 [INFO] Making environment variables for Terraform for myAwesomeMicroService:
 [INFO] - TF_VAR_githubToken from GITHUB_API_TOKEN
@@ -496,10 +496,10 @@ In order to use Makes you'll need to:
 
 1. Install Makes by running:
 
-   `$ nix-env -if https://github.com/fluidattacks/makes/archive/22.09.tar.gz`
+   `$ nix-env -if https://github.com/fluidattacks/makes/archive/22.10.tar.gz`
 
    We will install two commands in your system:
-   `$ m`, and `$ m-v22.09`.
+   `$ m`, and `$ m-v22.10`.
 
 Makes targets two kind of users:
 
@@ -603,7 +603,8 @@ for instance:
 {
   makesSrc = builtins.fetchGit {
     url = "https://github.com/fluidattacks/makes";
-    ref = "22.09";
+    ref = "refs/tags/22.10";
+    rev = ""  # Add a commit here
   };
 }
 ```
@@ -613,7 +614,7 @@ for instance:
 For the whole ecosystem to work
 you need to use the **same version**
 of the framework and the CLI.
-For example: `22.09`.
+For example: `22.10`.
 
 # Configuring CI/CD
 
@@ -662,7 +663,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - uses: docker://ghcr.io/fluidattacks/makes:22.09
+      - uses: docker://ghcr.io/fluidattacks/makes:22.10
         # You can use any name you like here
         name: helloWorld
         # You can pass secrets (if required) as environment variables like this:
@@ -686,7 +687,7 @@ looks like this:
 ```yaml
 # /path/to/my/project/.gitlab-ci.yaml
 /helloWorld:
-  image: ghcr.io/fluidattacks/makes:22.09
+  image: ghcr.io/fluidattacks/makes:22.10
   script:
     - m . /helloWorld 1 2 3
 # Add more jobs here, you can copy paste /helloWorld and modify the `script`
@@ -710,7 +711,7 @@ looks like this:
 os: linux
 language: nix
 nix: 2.3.12
-install: nix-env -if https://github.com/fluidattacks/makes/archive/22.09.tar.gz
+install: nix-env -if https://github.com/fluidattacks/makes/archive/22.10.tar.gz
 env:
   global:
     # Encrypted environment variable
@@ -1749,7 +1750,7 @@ Types:
         #
         # If you need to run jobs on different container images,
         # simply  create many `aws_batch_job_definition`s
-        image = "ghcr.io/fluidattacks/makes:22.09"
+        image = "ghcr.io/fluidattacks/makes:22.10"
 
         # Below arguments can be parametrized later,
         # but they are required for the job definition to be created
@@ -2616,7 +2617,7 @@ for [makeNodeJsEnvironment](#makenodejsenvironment)
 like this:
 
 ```bash
-m github:fluidattacks/makes@22.09 /utils/makeNodeJsLock \
+m github:fluidattacks/makes@22.10 /utils/makeNodeJsLock \
   "${node_js_version}" \
   "${package_json}" \
   "${package_lock}"
@@ -2636,7 +2637,7 @@ for [makePythonPypiEnvironment](#makepythonpypienvironment)
 like this:
 
 ```bash
-m github:fluidattacks/makes@22.09 /utils/makePythonLock \
+m github:fluidattacks/makes@22.10 /utils/makePythonLock \
   "${python_version}" \
   "${dependencies_yaml}" \
   "${sources_yaml}"
@@ -2661,7 +2662,7 @@ psycopg2: "2.9.1"
 You can generate an encrypted [Sops][sops] file like this:
 
 ```bash
-m github:fluidattacks/makes@22.09 /utils/makeSopsEncryptedFile \
+m github:fluidattacks/makes@22.10 /utils/makeSopsEncryptedFile \
   "${kms_key_arn}" \
   "${output}"
 ```
@@ -4253,7 +4254,7 @@ $ cat /path/to/my/project/makes/example/dependencies.yaml
 
   Django: "3.2.6"
 
-$ m github:fluidattacks/makes@22.09 /utils/makePythonLock \
+$ m github:fluidattacks/makes@22.10 /utils/makePythonLock \
     3.8 \
     /path/to/my/project/makes/example/dependencies.yaml \
     /path/to/my/project/makes/example/sources.yaml
@@ -5197,7 +5198,8 @@ let
   # Import the framework
   makes = import "${builtins.fetchGit {
     url = "https://github.com/fluidattacks/makes";
-    rev = "22.09";
+    ref = "refs/tags/22.10";
+    rev = ""  # Add a commit here
   }}/src/args/agnostic.nix" { };
 in
 # Use the framework

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 {system ? builtins.currentSystem}: let
   args = import ./src/args/agnostic.nix {inherit system;};
-  makesVersion = "22.09";
+  makesVersion = "22.10";
 
   inherit (args) __nixpkgs__;
   inherit (args) makeScript;

--- a/makes.nix
+++ b/makes.nix
@@ -27,7 +27,7 @@
         };
         registry = "ghcr.io";
         src = outputs."/container-image";
-        tag = "fluidattacks/makes:22.09";
+        tag = "fluidattacks/makes:22.10";
       };
     };
   };

--- a/src/cli/main/__main__.py
+++ b/src/cli/main/__main__.py
@@ -80,7 +80,7 @@ MAKES_DIR: str = join(environ["HOME_IMPURE"], ".makes")
 makedirs(join(MAKES_DIR, "cache"), exist_ok=True)
 SOURCES_CACHE: str = join(MAKES_DIR, "cache", "sources")
 ON_EXIT: List[Callable[[], None]] = []
-VERSION: str = "22.09"
+VERSION: str = "22.10"
 
 # Environment
 __MAKES_SRC__: str = environ["__MAKES_SRC__"]

--- a/src/evaluator/modules/pipelines/default.nix
+++ b/src/evaluator/modules/pipelines/default.nix
@@ -92,7 +92,7 @@
     name = toJobName output args;
     value = attrsMerge [
       {
-        image = "ghcr.io/fluidattacks/makes:22.09";
+        image = "ghcr.io/fluidattacks/makes:22.10";
         interruptible = true;
         needs = [];
         script =


### PR DESCRIPTION
- In september 2022 (22.09), the 22.09 tag, release and container, should be the stable version of Makes, and the 22.10 tag, release and container should be the unstable version.

  All development that happens during september 2022, should go to the 22.10 tag, release and container, because the docs promise that: "the current month release is frozen", so we shouldn't be modifying 22.09.