### PR TITLE
feat(build): #941 include openssh

### DIFF
--- a/makes/cli/env/runtime/main.nix
+++ b/makes/cli/env/runtime/main.nix
@@ -14,6 +14,7 @@ makeSearchPaths {
     __nixpkgs__.gnutar
     __nixpkgs__.gzip
     __nixpkgs__.nixStable
+    __nixpkgs__.openssh
   ];
   source = [
     outputs."/cli/env/runtime/pypi"

--- a/src/cli/main/cli.py
+++ b/src/cli/main/cli.py
@@ -108,9 +108,6 @@ if not NIX_STABLE:
     CON.out("Using feature flag: MAKES_NIX_UNSTABLE")
 
 
-# Constants
-
-
 def _if(condition: Any, *value: Any) -> List[Any]:
     return list(value) if condition else []
 


### PR DESCRIPTION
- Include openssh in the makes CLI, so that people can fetch private repositories
- Document this in the threat model, their possible dangers, and mitigation