### PR TITLE
feat(build): #944 doas make

### DIFF
--- a/makes/container-image/builder.sh
+++ b/makes/container-image/builder.sh
@@ -5,12 +5,15 @@
 # shellcheck shell=bash
 
 function configure_nix {
-  mkdir -p "${out}/home/makes/.config/nix" \
+  : \
+    && mkdir -p "${out}/home/makes/.config/nix" \
+    && mkdir -p "${out}/home/root/.config/nix" \
     && mkdir -p "${out}/etc/nix" \
     && mkdir -p "${out}/nix/store/.links" \
-    && mkdir -p "${out}/nix/var" \
+    && mkdir -p "${out}/nix/var/nix" \
     && echo 'build-users-group =' | tee \
       "${out}/home/makes/.config/nix/nix.conf" \
+      "${out}/home/root/.config/nix/nix.conf" \
       "${out}/etc/nix/nix.conf"
 }
 


### PR DESCRIPTION
- We cannot make the container fully non-root, but we can make makes run as makes.
- Expose this feature under a feature flag, since it has a small performance hit at the beginning while chown-ing /nix and also allowing us to test this without much risk