### PR TITLE
fix(build): #944 rm last set -x

### DIFF
--- a/makes/container-image/main.nix
+++ b/makes/container-image/main.nix
@@ -156,7 +156,6 @@ inputs.nixpkgs.dockerTools.buildImage {
             chown makes:makes --recursive "$PWD"
 
             ${inputs.nixpkgs.doas}/bin/doas -u makes ${outputs."/"}/bin/m "$@"
-            set +x
           fi
         '')
       ];


### PR DESCRIPTION
- This way the exit code is propagated from the makes job