### PR TITLE
refac(back): #1045 update commit linter

### DIFF
--- a/src/evaluator/modules/lint-git-commit-msg/default.nix
+++ b/src/evaluator/modules/lint-git-commit-msg/default.nix
@@ -30,7 +30,7 @@
       };
     };
   };
-  config = attrsOptional isLinux {
+  config = {
     outputs = {
       "/lintGitCommitMsg" =
         lib.mkIf


### PR DESCRIPTION
- The linter is usable in macOS, the `isLinux` verification is not needed