### PR TITLE
refac(doc): #1045 update docs

### DIFF
--- a/docs/src/api/builtins/lint.md
+++ b/docs/src/api/builtins/lint.md
@@ -74,10 +74,6 @@ Example:
 
 ## lintGitCommitMsg
 
-???+ warning
-
-    This function is only available on Linux at the moment.
-
 It creates a commit diff
 between you current branch
 and the main branch of the repository.


### PR DESCRIPTION
- `lintGitCommitMsg` is now usable in macOS