### PR TITLE
feat(back): #1087 enable custom rulesets for the lintMarkdown builtin

### DIFF
--- a/src/args/lint-markdown/builder.sh
+++ b/src/args/lint-markdown/builder.sh
@@ -6,7 +6,7 @@ function main {
   info Linting Markdown code \
     && for target in "${targets[@]}"; do
       info Linting "${target}" \
-        && mdl --ignore-front-matter --style "${envConfig}" "${target}" \
+        && mdl --ignore-front-matter --style "${envConfig}" --rulesets "${envRulesets}" "${target}" \
         || return 1
     done \
     && touch "${out}"

--- a/src/args/lint-markdown/default.nix
+++ b/src/args/lint-markdown/default.nix
@@ -7,11 +7,13 @@
   name,
   config,
   targets,
+  rulesets,
 }:
 makeDerivation {
   env = {
     envConfig = config;
     envTargets = toBashArray targets;
+    envRulesets = rulesets;
   };
   name = "lint-markdown-for-${name}";
   searchPaths = {

--- a/src/evaluator/modules/lint-markdown/default.nix
+++ b/src/evaluator/modules/lint-markdown/default.nix
@@ -11,6 +11,7 @@
   makeOutput = name: {
     config,
     targets,
+    rulesets,
   }: {
     name = "/lintMarkdown/${name}";
     value = lintMarkdown {
@@ -20,6 +21,10 @@
         then ./config.rb
         else projectPath config;
       targets = builtins.map projectPath targets;
+      rulesets =
+        if rulesets == null
+        then ./rulesets.rb
+        else projectPath rulesets;
     };
   };
 in {
@@ -34,6 +39,10 @@ in {
           };
           targets = lib.mkOption {
             type = lib.types.listOf lib.types.str;
+          };
+          rulesets = lib.mkOption {
+            default = null;
+            type = lib.types.nullOr lib.types.str;
           };
         };
       }));

--- a/src/evaluator/modules/lint-markdown/rulesets.rb
+++ b/src/evaluator/modules/lint-markdown/rulesets.rb
@@ -1,0 +1,1 @@
+# Set custom rule sets here


### PR DESCRIPTION
- Add a new parameter --rulesets to the lintMarkdown linter implementation, which allows passing the file with custom rules for Markdownlint.
- Add a new default rulesets.rb file