### PR TITLE
feat(back): #1101 globbed attrs

### DIFF
--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -10,6 +10,8 @@
 # You better avoid changing this function signature...
 # Ask a maintainer first.
 {
+  # JSON String containing complete list of main.nix files found within projectSrc
+  attrPaths,
   # flake inputs to inject, if any
   flakeInputs ? {},
   # Source code of makes, can be overriden by the user.
@@ -56,7 +58,7 @@
       "${makesSrcOverriden}/src/evaluator/modules/default.nix"
       makesNix
     ];
-    specialArgs = args;
+    specialArgs = args // {inherit attrPaths;};
   };
 in
   result


### PR DESCRIPTION
- Collect attr paths using python globs for initialization performance
- Pass them as attrPaths to evaluator
- Redefine evaluator logic for building outputs from attrs
- Initialization for universe takes less than 3 seconds now