### PR TITLE
feat(build): #1099 fix testlicense bug

### DIFF
--- a/docs/src/api/builtins/test.md
+++ b/docs/src/api/builtins/test.md
@@ -4,7 +4,9 @@ Test the license of a project using [reuse](https://reuse.software/).
 
 Types:
 
-- testLicense: Empty attribute set.
+- testLicense:
+    - enable (`bool`): Optional.
+        Defaults to `false`.
 
 Example:
 
@@ -12,7 +14,9 @@ Example:
 
     ```nix
     {
-      testLicense = {};
+      testLicense = {
+        enable = true;
+      };
     }
     ```
 

--- a/makes.nix
+++ b/makes.nix
@@ -252,7 +252,9 @@
       };
     };
   };
-  testLicense = {};
+  testLicense = {
+    enable = true;
+  };
   testPython = {
     example = {
       python = "3.11";

--- a/src/evaluator/modules/test-license/default.nix
+++ b/src/evaluator/modules/test-license/default.nix
@@ -4,11 +4,16 @@
   ...
 }: {
   options = {
-    testLicense = {};
+    testLicense = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+      };
+    };
   };
   config = {
     outputs = {
-      "/testLicense" = testLicense;
+      "/testLicense" = lib.mkIf config.testLicense.enable testLicense;
     };
   };
 }


### PR DESCRIPTION
- fix `testLicense` still appears when there are no references.