### PR TITLE
feat(build): #1126 retry makepythonpypienvironment

### DIFF
--- a/src/args/make-python-pypi-environment/default.nix
+++ b/src/args/make-python-pypi-environment/default.nix
@@ -104,7 +104,7 @@ assert builtins.any (_: _) [
             inherit name;
             inherit sha256;
             inherit url;
-            curlOptsList = ["--retry" "3"];
+            curlOptsList = ["--retry" "3" "--fail"];
           };
         })
         (builtins.concatLists [


### PR DESCRIPTION
- Add `--fail` to retry on HTTP 5XX response code (`curl: (35) Send failure: Connection reset by peer`)