### PR TITLE
refac(back): #1172 ignore win-arm64 wheels

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -20,6 +20,8 @@ Github Octocat <noreply@github.com> GitHub <noreply@github.com>
 GuangTao Zhang <gtrunsec@hardenedlinux.org> GTrunSec <gtrunsec@hardenedlinux.org>
 John Perez <jperez@fluidattacks.com> John Perez <34050007+jpverde@users.noreply.github.com>
 John Perez <mrjohnjairo10@gmail.com> John Perez <mrjohnjairo10@gmail.com>
+Julian Gomez <jgomezb11@eafit.edu.co> Julian Gomez <jgomezb11@eafit.edu.co>
+Julian Gomez Benitez <60365681+jgomezb11@users.noreply.github.com> Julian Gomez Benitez <60365681+jgomezb11@users.noreply.github.com>
 Kevin Amado <kamadorueda@gmail.com> Kevin Amado <kamadorueda@gmail.com>
 Luis Saavedra <lsaavedra@fluidattacks.com> Luis David Saavedra <40694133+ludsrill@users.noreply.github.com>
 Luis Saavedra <lsaavedra@fluidattacks.com> Luis Saavedra <lsaavedra@fluidattacks.com>

--- a/src/args/make-python-vscode-settings/default.nix
+++ b/src/args/make-python-vscode-settings/default.nix
@@ -2,8 +2,7 @@
   __nixpkgs__,
   makeTemplate,
   ...
-}:
-{
+}: {
   name,
   env,
   bins,

--- a/src/args/python-override-utils/default.nix
+++ b/src/args/python-override-utils/default.nix
@@ -48,7 +48,8 @@ let
   compose = let
     # definition from nixpkgs.lib.reverseList
     reverseList = xs: let l = builtins.length xs; in builtins.genList (n: builtins.elemAt xs (l - n - 1)) l;
-  in functions: val: builtins.foldl' (x: f: f x) val (reverseList functions);
+  in
+    functions: val: builtins.foldl' (x: f: f x) val (reverseList functions);
 in {
   inherit compose recursive_python_pkg_override no_check_override replace_pkg;
 }


### PR DESCRIPTION
- add exclusion for win_arm64 wheels inside makePythonLock
- exclude packages without links from the sources.yaml