### PR TITLE
refac(back): #1200 remove prefix

### DIFF
--- a/src/args/lint-python/builder.sh
+++ b/src/args/lint-python/builder.sh
@@ -12,7 +12,7 @@ function main {
   local python_dirs
   local python_dir
 
-  package_name="$(basename "${envSrc##*-}")" \
+  package_name="$(basename "${envSrc#*-}")" \
     && info Running mypy over: "${package_path}", package "${package_name}" \
     && if ! test -e "${package_path}/py.typed"; then
       error This is not a mypy package, py.typed missing

--- a/src/args/project-path/default.nix
+++ b/src/args/project-path/default.nix
@@ -1,6 +1,7 @@
 {
   hasPrefix,
   projectSrc,
+  removePrefix,
   ...
 }: rel:
 if hasPrefix "/" rel
@@ -13,7 +14,7 @@ then
     name =
       if rel == "/"
       then "src"
-      else builtins.replaceStrings ["/"] ["-"] rel;
+      else removePrefix "." (builtins.baseNameOf rel);
     path = (builtins.unsafeDiscardStringContext projectSrc) + rel;
   })
 else abort "projectPath arguments must start with: /, currently it is: ${rel}"


### PR DESCRIPTION
- Keep using basename in order to avoid errors
- Remove prefix dot if basename contains it
- get package_name the old way