### PR TITLE
feat(build): #1212 upgrade makenodejslock parameters

### DIFF
--- a/docs/src/api/builtins/utilities.md
+++ b/docs/src/api/builtins/utilities.md
@@ -11,16 +11,14 @@ like this:
 ```bash
 m github:fluidattacks/makes@23.07 /utils/makeNodeJsLock \
   "${node_js_version}" \
-  "${package_json}" \
-  "${package_lock}"
+  "${package_json_dir}"
 ```
 
 - Supported `node_js_version`s are: `14`, `16` and `18`.
-- `package_json` is the **absolute path** to the `package.json` file in your
-    project.
-- `package_lock` is the **absolute path**
-    to the `package-lock.json` file in your project, this file can be an empty
-    file.
+- `package_json_dir` is the **absolute path** to the directory that contains
+    the `package.json` file in your project.
+- The `package-lock.json` file will be generated in the same directory that
+    contains the `package.json` file.
 
 ## makePythonLock
 

--- a/makes/utils/makeNodeJsLock/entrypoint.sh
+++ b/makes/utils/makeNodeJsLock/entrypoint.sh
@@ -2,21 +2,19 @@
 
 function main {
   local node_js_version="${1}"
-  local package_json="${2}"
+  local package_json_dir="${2}"
   local npm_install_args=(
     --audit false
     --ignore-scripts true
   )
-  local dir_package_json
 
-  : && dir_package_json=$(dirname "${package_json}") \
-    && case "${node_js_version}" in
+  : && case "${node_js_version}" in
       14) npm=__argNode14__/bin/npm ;;
       16) npm=__argNode16__/bin/npm ;;
       18) npm=__argNode18__/bin/npm ;;
       *) critical NodeJs version not supported: "${node_js_version}" ;;
     esac \
-    && pushd "${dir_package_json}" \
+    && pushd "${package_json_dir}" \
     && "${npm}" install "${npm_install_args[@]}" \
     && popd || return 1
 }


### PR DESCRIPTION
- `makeNodeJsLock` now receives the directory that contains the `package.json` file instead of the `package.json` file itself.
- The `package-lock.json` file will be generated in the same directory that contains the `package.json` file.
- `makeNodeJsLock` now only receives two parameters: `node_js_version` and `package_json_dir`.
- Removed `package_lock` parameter from `makeNodeJsLock`.
- Updated `makeNodeJsLock` documentation.