### PR TITLE
feat(build): #1202 pin nix version

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
+Andres Cuberos <acuberos@fluidattacks.com> Andres Cuberos <acuberos@fluidattacks.com>
 Andres Cuberos <acuberos@fluidttacks.com> Andres Cuberos <31192632+acuberosatfluid@users.noreply.github.com>
-Andres Cuberos <acuberos@fluidttacks.com> Andres Cuberos <acuberos@fluidttacks.com>
 Daniel Murcia <danmur97@outlook.com> Daniel F. Murcia Rivera <danmur97@outlook.com>
 Daniel Murcia <danmur97@outlook.com> Daniel Murcia <42251914+danmur97@users.noreply.github.com>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalaza4@eafit.edu.co>

--- a/makes/main.nix
+++ b/makes/main.nix
@@ -15,13 +15,11 @@ in
     ];
     replace = {
       __argMakesSrc__ = projectPath "/";
-      __argNixStable__ = __nixpkgs__.nixStable;
-      __argNixUnstable__ = __nixpkgs__.nixUnstable;
+      __argNix__ = __nixpkgs__.nixVersions.nix_2_15;
     };
     entrypoint = ''
       __MAKES_SRC__=__argMakesSrc__ \
-      __NIX_STABLE__=__argNixStable__ \
-      __NIX_UNSTABLE__=__argNixUnstable__ \
+      __NIX__=__argNix__ \
       python -u __argMakesSrc__/src/cli/main/__main__.py "$@"
     '';
     searchPaths.source = [

--- a/src/cli/main/cli.py
+++ b/src/cli/main/cli.py
@@ -82,8 +82,7 @@ VERSION: str = "23.07"
 
 # Environment
 __MAKES_SRC__: str = environ["__MAKES_SRC__"]
-__NIX_STABLE__: str = environ["__NIX_STABLE__"]
-__NIX_UNSTABLE__: str = environ["__NIX_UNSTABLE__"]
+__NIX__: str = environ["__NIX__"]
 
 
 # Feature flags
@@ -101,10 +100,6 @@ K8S_COMPAT: bool = bool(environ.get("MAKES_K8S_COMPAT"))
 if K8S_COMPAT:
     CON.out("Using feature flag: MAKES_K8S_COMPAT")
 
-NIX_STABLE: bool = not bool(environ.get("MAKES_NIX_UNSTABLE"))
-if not NIX_STABLE:
-    CON.out("Using feature flag: MAKES_NIX_UNSTABLE")
-
 
 def _if(condition: Any, *value: Any) -> List[Any]:
     return list(value) if condition else []
@@ -118,11 +113,7 @@ def _clone_src(src: str) -> str:
     ON_EXIT.append(partial(shutil.rmtree, head, ignore_errors=True))
 
     if abspath(src) == CWD:  # `m .` ?
-        if NIX_STABLE:
-            _clone_src_git_worktree_add(src, head)
-        else:
-            # Nix with Flakes already ensures a pristine git repo
-            head = src
+        _clone_src_git_worktree_add(src, head)
     else:
         if (
             (match := _clone_src_github(src))
@@ -286,16 +277,13 @@ def _nix_build(
             ]
         )
     return [
-        *_if(NIX_STABLE, f"{__NIX_STABLE__}/bin/nix-build"),
-        *_if(not NIX_STABLE, f"{__NIX_UNSTABLE__}/bin/nix"),
-        *_if(not NIX_STABLE, "--experimental-features", "flakes nix-command"),
-        *_if(not NIX_STABLE, "build"),
-        *_if(NIX_STABLE, "--argstr", "makesSrc", __MAKES_SRC__),
-        *_if(NIX_STABLE, "--argstr", "projectSrc", head),
+        *[f"{__NIX__}/bin/nix-build"],
+        *["--argstr", "makesSrc", __MAKES_SRC__],
+        *["--argstr", "projectSrc", head],
         *["--argstr", "attrPaths", attr_paths],
-        *_if(NIX_STABLE, "--attr", attr),
+        *["--attr", attr],
         *["--option", "cores", "0"],
-        *_if(not NIX_STABLE, "--impure"),
+        *["--impure"],
         *["--option", "narinfo-cache-negative-ttl", "1"],
         *["--option", "narinfo-cache-positive-ttl", "1"],
         *["--option", "max-jobs", "auto"],
@@ -305,15 +293,14 @@ def _nix_build(
         *_if(out, "--out-link", out),
         *_if(not out, "--no-out-link"),
         *["--show-trace"],
-        *_if(NIX_STABLE, f"{__MAKES_SRC__}/src/evaluator/default.nix"),
-        *_if(not NIX_STABLE, attr),
+        *[f"{__MAKES_SRC__}/src/evaluator/default.nix"],
     ]
 
 
 def _nix_hashes(paths: bytes) -> List[str]:
     cmd = [
         "xargs",
-        f"{__NIX_STABLE__}/bin/nix-store",
+        f"{__NIX__}/bin/nix-store",
         "--query",
         "--hash",
     ]
@@ -326,13 +313,13 @@ def _nix_hashes(paths: bytes) -> List[str]:
 
 def _nix_build_requisites(path: str) -> List[Tuple[str, str]]:
     """Answer the question: what do I need to build `out`."""
-    cmd = [f"{__NIX_STABLE__}/bin/nix-store", "--query", "--deriver", path]
+    cmd = [f"{__NIX__}/bin/nix-store", "--query", "--deriver", path]
     out, stdout, _ = _run_outputs(cmd, stderr=None)
     if out != 0:
         raise SystemExit(out)
 
     cmd = [
-        f"{__NIX_STABLE__}/bin/nix-store",
+        f"{__NIX__}/bin/nix-store",
         "--query",
         "--requisites",
         "--include-outputs",
@@ -359,7 +346,7 @@ def _get_head(src: str) -> str:
     head: str = _clone_src(src)
 
     # Applies only to local repositories on non-flakes Nix
-    if abspath(src) == CWD and NIX_STABLE:  # `m .` ?
+    if abspath(src) == CWD:  # `m .` ?
         paths: Set[str] = set()
 
         # Propagated `git add`ed files
@@ -410,15 +397,13 @@ def _get_config(head: str, attr_paths: str) -> Config:
     out: str = _get_named_temporary_file_name()
     code = _run(
         args=_nix_build(
-            attr="config.configAsJson"
-            if NIX_STABLE
-            else f'{head}#__makes__."config:configAsJson"',
+            attr="config.configAsJson",
             attr_paths=attr_paths,
             cache=None,
             head=head,
             out=out,
         ),
-        env=None if NIX_STABLE else dict(HOME=environ["HOME_IMPURE"]),
+        env=None,
         stderr=None,
         stdout=sys.stderr.fileno(),
     )
@@ -626,15 +611,13 @@ def _cli_build(  # pylint: disable=too-many-arguments
 
     code = _run(
         args=_nix_build(
-            attr=f'config.outputs."{attr}"'
-            if NIX_STABLE
-            else f'{head}#__makes__."config:outputs:{attr}"',
+            attr=f'config.outputs."{attr}"',
             attr_paths=attr_paths,
             cache=config.cache,
             head=head,
             out=out,
         ),
-        env=None if NIX_STABLE else dict(HOME=environ["HOME_IMPURE"]),
+        env=None,
         stderr=None,
         stdout=None,
     )

--- a/src/evaluator/default.nix
+++ b/src/evaluator/default.nix
@@ -12,8 +12,6 @@
 {
   # JSON String containing complete list of main.nix files found within projectSrc
   attrPaths,
-  # flake inputs to inject, if any
-  flakeInputs ? {},
   # Source code of makes, can be overriden by the user.
   makesSrc,
   # Path to the user's project, inside a sandbox.
@@ -41,7 +39,7 @@
     else makesSrc;
 
   args = import "${makesSrcOverriden}/src/args/default.nix" {
-    inputs = flakeInputs // result.config.inputs;
+    inherit (result.config) inputs;
     inherit (result.config) outputs;
     inherit (result.config) projectIdentifier;
     inherit projectSrc;

--- a/src/nix/sources.json
+++ b/src/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
-        "sha256": "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
+        "sha256": "1dbkg2b7fpxapwh30pk191rmiwx2fgg9qls628lv4x2cjcdi2wia",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/aa9d4729cbc99dabacb50e3994dcefb3ea0f7447.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
- Based on https://github.com/fluidattacks/makes/pull/1220

- Pin nix version to 2.15 as it looks like 2.16 brings breaking changes for current back pinning
method.

- Stop supporting nix unstable as it is broken and no being used.

- Update nixpkgs to support latest nodejs version.

- Add `impure` flag to nix-build command.