### PR TITLE
feat(build): #1282 assure purity removing dir

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,7 @@
 Andres Cuberos <acuberos@fluidttacks.com> Andres Cuberos <31192632+acuberosatfluid@users.noreply.github.com>
 Andres Cuberos <acuberos@fluidttacks.com> Andres Cuberos <acuberos@fluidattacks.com>
 Brandon Lotero <blotero@fluidattacks.com> Brandon Lotero <blotero@fluidattacks.com>
+Briam Agudelo <bridamo.98@gmail.com> Briam Agudelo <bridamo.98@gmail.com>
 Daniel Murcia <danmur97@outlook.com> Daniel F. Murcia Rivera <danmur97@outlook.com>
 Daniel Murcia <danmur97@outlook.com> Daniel Murcia <42251914+danmur97@users.noreply.github.com>
 Daniel Salazar <podany270895@gmail.com> Daniel Salazar <dsalaza4@eafit.edu.co>


### PR DESCRIPTION
- Update mailmap
- Set `HOME` to a temp dir
- Remove `homeless-shelter` dir if it exists
- Create external function to fetch all packages
names from a TOML file, including the extras

Approach:
- Read the TOML file and get the packages.
- Override the `preUnpack` function to set
`HOME` to a temp dir.
- Override the `overrides` function to combine,
in case of conflict, the `overrides` that was passed
will be the one that prevails.