### PR TITLE
feat(build): #1293 fix homeless shelter issue

### DIFF
--- a/src/args/lint-python-imports/default.nix
+++ b/src/args/lint-python-imports/default.nix
@@ -23,7 +23,15 @@ makeDerivation {
       pythonVersion = "3.11";
       overrides = self: super: {
         grimp = super.grimp.overridePythonAttrs (
-          old: {buildInputs = [super.setuptools];}
+          old: {
+            preUnpack =
+              ''
+                export HOME=$(mktemp -d)
+                rm -rf /homeless-shelter
+              ''
+              + (old.preUnpack or "");
+            buildInputs = [super.setuptools];
+          }
         );
         import-linter = super.import-linter.overridePythonAttrs (
           old: {buildInputs = [super.setuptools];}


### PR DESCRIPTION
- Add a `preUnpack` hook to the `grimp` derivation to set the `HOME` environment variable to a
temporary directory and remove the `/homeless-shelter` directory.