### PR TITLE
feat(build): #1293 fix homeless shelter issue

### DIFF
--- a/src/args/lint-python-imports/default.nix
+++ b/src/args/lint-python-imports/default.nix
@@ -34,7 +34,15 @@ makeDerivation {
           }
         );
         import-linter = super.import-linter.overridePythonAttrs (
-          old: {buildInputs = [super.setuptools];}
+          old: {
+            preUnpack =
+              ''
+                export HOME=$(mktemp -d)
+                rm -rf /homeless-shelter
+              ''
+              + (old.preUnpack or "");
+            buildInputs = [super.setuptools];
+          }
         );
       };
     })


### PR DESCRIPTION
- Add `preUnpack` hook to `import-linter` to set `HOME` to a temporary directory and remove
`/homeless-shelter`.