### PR TITLE
feat(docs): #1296 add note about homeless-shelter

### DIFF
--- a/docs/src/api/extensions/fundamentals.md
+++ b/docs/src/api/extensions/fundamentals.md
@@ -527,14 +527,14 @@ Types:
         to `projectStateDir` otherwise.
         Defaults to `false`, if `projectStateDir` is specified or derived.
 
-        Note:
+        ???+ note
 
-        - It is implicitly `true`, if `projectStateDir == globalStateDir`.
-        - `projectStateDir == globalStateDir` is the default if
-          `projectIdentifier` is not configured.
-        - Hence, generally enable project local state by
-            - either setting `projectIdentifier`
-            - or `projectStateDir` different from `globalStateDir`.
+            - It is implicitly `true`, if `projectStateDir == globalStateDir`.
+            - `projectStateDir == globalStateDir` is the default if
+            `projectIdentifier` is not configured.
+            - Hence, generally enable project local state by
+                - either setting `projectIdentifier`
+                - or `projectStateDir` different from `globalStateDir`.
 
 Example:
 

--- a/docs/src/api/extensions/python.md
+++ b/docs/src/api/extensions/python.md
@@ -24,6 +24,12 @@ Types:
         For more information see [here](https://github.com/nix-community/poetry2nix/blob/master/docs/edgecases.md).
         Defaults to `(self: super: {})`.
 
+        ???+ note
+
+            By default we override every python package deleting the
+            `homeless-shelter` directory and changing the `HOME` variable,
+            we make this to assure purity of builds without sandboxing.
+
 Example:
 
 === "main.nix"
@@ -43,6 +49,12 @@ Example:
       overrides = self: super: {
         pygments = super.pygments.overridePythonAttrs (
           old: {
+            preUnpack =
+              ''
+                export HOME=$(mktemp -d)
+                rm -rf /homeless-shelter
+              ''
+              + (old.preUnpack or "");
             buildInputs = [super.setuptools];
           }
         );


### PR DESCRIPTION
- Add note about homeless-shelter in the python extension documentation to make sure that the user knows that we delete this directory and change the `HOME` variable to assure purity of builds without sandboxing.