### PR TITLE
feat(build): #1298 dmypy use start and stop

### DIFF
--- a/src/args/lint-python/builder.sh
+++ b/src/args/lint-python/builder.sh
@@ -20,7 +20,9 @@ function main {
     && tmpdir="$(mktemp -d)" \
     && copy "${package_path}" "${tmpdir}/${package_name}" \
     && pushd "${tmpdir}" \
-    && dmypy run -- --config-file "${envSettingsMypy}" "${package_name}" \
+    && dmypy start -- --config-file "${envSettingsMypy}" \
+    && dmypy check "${package_name}" \
+    && dmypy stop \
     && python_dirs=() \
     && current_python_dir="" \
     && find . -name '*.py' > tmp \
@@ -32,11 +34,13 @@ function main {
         && current_python_dir="${python_dir}" \
         || return 1
     done < tmp \
+    && dmypy start -- --config-file "${envSettingsMypy}" \
     && for dir in "${python_dirs[@]}"; do
       info Running mypy over: "${package_path}", folder "${dir}" \
-        && dmypy run -- --config-file "${envSettingsMypy}" "${dir}" \
+        && dmypy check "${dir}" \
         || return 1
     done \
+    && dmypy stop \
     && popd \
     && info Running prospector over: "${package_path}", package "${package_name}" \
     && if ! test -e "${package_path}/__init__.py"; then


### PR DESCRIPTION
- use `dmypy start` and `dmypy stop` instead of `dmypy run`
- use `follow-imports=skip` to fall back to the stable functionality of `dmypy`