### PR TITLE
fix(doc): #1304 fix broken urls

### DIFF
--- a/docs/src/api/builtins/deploy.md
+++ b/docs/src/api/builtins/deploy.md
@@ -171,7 +171,7 @@ Types:
         Sign container image
         with [Cosign](https://docs.sigstore.dev/cosign/overview/)
         by using a
-        [OIDC keyless approach](https://docs.sigstore.dev/cosign/keyless/).
+        [OIDC keyless approach](https://docs.sigstore.dev/signing/quickstart/#keyless-signing-of-a-container).
         Defaults to `false`.
     - src (`package`):
         Derivation that contains the container image in OCI Format.

--- a/docs/src/api/extensions/containers.md
+++ b/docs/src/api/extensions/containers.md
@@ -31,7 +31,7 @@ Types:
         Defaults to `65`.
     - config (`attrsOf anything`): Optional.
         Configuration manifest as described in
-        [OCI Runtime Configuration Manifest](https://github.com/moby/moby/blob/master/image/spec/v1.2.)
+        [OCI Runtime Configuration Manifest](https://github.com/moby/docker-image-spec)
         Defaults to `{ }`.
 
 Example:


### PR DESCRIPTION
- past "OIDC keyless approach" url was deprecated, new url points to the new documentation
- past "OCI Runtime Configuration Manifest" url was wrong (the ".md" extension was missing) and fixed url points to a message that announce that documentation was moved to a separate repository