### PR TITLE
fix(doc): #1304 update site - name

### DIFF
--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -1,4 +1,4 @@
-site_name: Makes | Software supply chain framework | Fluid Attacks
+site_name: Makes | Fluid Attacks
 site_url: https://makes.fluidattacks.com/
 site_description: Documentation for Makes
 site_author: Fluid Attacks


### PR DESCRIPTION
- since the site name is being added to the title tag in each
page, we should keep it simple to
avoid warnings