### PR TITLE
fix(doc): #1304 update site_name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,6 @@
 Andres Cuberos <acuberos@fluidttacks.com> Andres Cuberos <31192632+acuberosatfluid@users.noreply.github.com>
 Andres Cuberos <acuberos@fluidttacks.com> Andres Cuberos <acuberos@fluidattacks.com>
+Andres Saldarriaga <saldarias753@outlook.com> Andres Saldarriaga <saldarias753@outlook.com>
 Brandon Lotero <blotero@fluidattacks.com> Brandon Lotero <blotero@fluidattacks.com>
 Briam Agudelo <bridamo.98@gmail.com> Briam Agudelo <bridamo.98@gmail.com>
 Daniel Murcia <danmur97@outlook.com> Daniel F. Murcia Rivera <danmur97@outlook.com>

--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -1,4 +1,4 @@
-site_name: Makes | Software supply chain framework | Fluid Attacks
+site_name: Makes | Fluid Attacks
 site_url: https://makes.fluidattacks.com/
 site_description: Documentation for Makes
 site_author: Fluid Attacks


### PR DESCRIPTION
- since the site name is being added to the title tag in each
page, we should keep it simple to
avoid warnings