### PR TITLE
feat(back): #1314 upgrade lint-git-mailmap

### DIFF
--- a/docs/src/api/builtins/lint.md
+++ b/docs/src/api/builtins/lint.md
@@ -130,6 +130,10 @@ Types:
 - lintGitMailmap:
     - enable (`boolean`): Optional.
         Defaults to `false`.
+    - exclude (`str`): Optional.
+        If the excludes aren't too many then use `exclude` instead
+        of the exclude file (`.mailmap-exclude`).
+        Defaults to `^$`.
 
 Example:
 
@@ -139,6 +143,7 @@ Example:
     {
       lintGitMailMap = {
         enable = true;
+        exclude = "^.* <.*noreply@github.com>$";
       };
     }
     ```

--- a/src/args/lint-git-mailmap/default.nix
+++ b/src/args/lint-git-mailmap/default.nix
@@ -6,18 +6,20 @@
 }: {
   name,
   src,
+  exclude,
 }: let
   mailmapLinter = fetchGithub {
     owner = "kamadorueda";
     repo = "mailmap-linter";
-    rev = "a51ac7e44515c754938a08f81038762e7d09a827";
-    sha256 = "1da49y2cw9g9i4gbd2ykqghnpqpqdac18lafmn878qdlf1v8n9lh";
+    rev = "ffed6a68e507228d7e462642a8ec129f816b6a5d";
+    sha256 = "XHmqLTT7TZ/dXBtQSH1xkEGSWI4mpImt+KRqBHbfGLk=";
   };
 in
   makeScript {
     entrypoint = ./entrypoint.sh;
     replace = {
       __argSrc__ = src;
+      __argExclude__ = exclude;
     };
     name = "lint-git-mailmap-for-${name}";
     searchPaths = {

--- a/src/args/lint-git-mailmap/entrypoint.sh
+++ b/src/args/lint-git-mailmap/entrypoint.sh
@@ -2,7 +2,7 @@
 
 function main {
   cd '__argSrc__' \
-    && mailmap-linter
+    && mailmap-linter --exclude '__argExclude__'
 }
 
 main "${@}"

--- a/src/evaluator/modules/lint-git-mailmap/default.nix
+++ b/src/evaluator/modules/lint-git-mailmap/default.nix
@@ -9,6 +9,10 @@
         default = false;
         type = lib.types.bool;
       };
+      exclude = lib.mkOption {
+        default = "^$";
+        type = lib.types.str;
+      };
     };
   };
   config = {
@@ -19,6 +23,7 @@
         (lintGitMailMap {
           name = "lint-git-mailmap";
           src = ".";
+          inherit (config.lintGitMailMap) exclude;
         });
     };
   };


### PR DESCRIPTION
- Upgrade to the latest version of mailmap-linter
- Add a `exclude` option to the lint-git-mailmap module
- Add a `--exclude` option to the entrypoint script
- Update documentation