### PR TITLE
feat(back): #1317 fix makenodejslock

### DIFF
--- a/makes/utils/makeNodeJsLock/entrypoint.sh
+++ b/makes/utils/makeNodeJsLock/entrypoint.sh
@@ -3,10 +3,11 @@
 function main {
   local node_js_version="${1}"
   local package_json_dir="${2}"
-  local lockfile_version="${3:2}"
+  local lockfile_version="${3:-2}"
   local npm_install_args=(
     --audit false
     --ignore-scripts true
+    --package-lock-only
   )
 
   : && case "${node_js_version}" in


### PR DESCRIPTION
- add `--package-lock-only` to `npm install` command
- fix default value for `lockfile_version` in `entrypoint.sh`