### PR TITLE
feat(back): #1332 add check flag to nixfmt

### DIFF
--- a/docs/src/api/builtins/format.md
+++ b/docs/src/api/builtins/format.md
@@ -80,7 +80,7 @@ Example:
 ## formatNix
 
 Ensure that Nix code is formatted
-according to [Alejandra](https://github.com/kamadorueda/alejandra).
+according to [nixfmt](https://github.com/NixOS/nixfmt).
 
 Types:
 

--- a/src/args/format-nix/entrypoint.sh
+++ b/src/args/format-nix/entrypoint.sh
@@ -2,11 +2,15 @@
 
 function main {
   source __argTargets__/template local targets
+  local args=()
 
   info Formatting Nix code \
+    && if running_in_ci_cd_provider; then
+      args+=(--check)
+    fi \
     && for target in "${targets[@]}"; do
       info Formatting "${target}" \
-        && if ! nixfmt "${target}"; then
+        && if ! nixfmt "${args[@]}" "${target}"; then
           info Source code was formated, the job will fail \
             && error Failing as promised...
         fi \


### PR DESCRIPTION
- Run check only in CI, locally it will format the code
- Update docs to show the use of nixfmt instead of Alejandra