### PR TITLE
feat(back): #1347 fix lintpython typo

### DIFF
--- a/docs/src/api/builtins/lint.md
+++ b/docs/src/api/builtins/lint.md
@@ -245,7 +245,7 @@ and (if configured) [import-linter](https://import-linter.readthedocs.io/en/stab
 Types:
 
 - lintPython:
-    - dirsOfModules (`attrsOf dirOfModulesType`): Optional.
+    - dirOfModules (`attrsOf dirOfModulesType`): Optional.
         Definitions of directories of python packages/modules to lint.
         Defaults to `{ }`.
     - imports (`attrsOf importsType`): Optional.
@@ -296,7 +296,7 @@ Example:
     ```nix
     {
       lintPython = {
-        dirsOfModules = {
+        dirOfModules = {
           makes = {
             config = {};
             src = "/src/cli";

--- a/makes.nix
+++ b/makes.nix
@@ -145,7 +145,7 @@
   };
   lintPython = let searchPaths.source = [ outputs."/cli/env/runtime" ];
   in {
-    dirsOfModules = {
+    dirOfModules = {
       makes = {
         inherit searchPaths;
         src = "/src/cli";

--- a/src/evaluator/modules/lint-python/default.nix
+++ b/src/evaluator/modules/lint-python/default.nix
@@ -45,7 +45,7 @@ let
 in {
   options = {
     lintPython = {
-      dirsOfModules = lib.mkOption {
+      dirOfModules = lib.mkOption {
         default = { };
         type = lib.types.attrsOf (lib.types.submodule (_: {
           options = {
@@ -106,7 +106,7 @@ in {
   };
   config = {
     outputs =
-      (__toModuleOutputs__ makeDirOfModules config.lintPython.dirsOfModules)
+      (__toModuleOutputs__ makeDirOfModules config.lintPython.dirOfModules)
       // (__toModuleOutputs__ makeImports config.lintPython.imports)
       // (__toModuleOutputs__ makeModule config.lintPython.modules);
   };


### PR DESCRIPTION
- Fix typo in lintPython attribute `dirsOfModules` to `dirOfModules`.