### PR TITLE
feat(doc): #1349 update vuln dependency

### DIFF
--- a/makes/docs/runtime/pypi/poetry.lock
+++ b/makes/docs/runtime/pypi/poetry.lock
@@ -16,13 +16,13 @@ dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
 name = "certifi"
-version = "2024.6.2"
+version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
-    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
+    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
+    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
 ]
 
 [[package]]
@@ -727,4 +727,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3a9002d654b31d7f35c64a790dc1ba70ec2ef061a2f0dfb96fbc1a865ee43db0"
+content-hash = "01d7707074d0e0615f7168f96f04a9d420c0c784d6a89ad80797221bc52fe133"

--- a/makes/docs/runtime/pypi/pyproject.toml
+++ b/makes/docs/runtime/pypi/pyproject.toml
@@ -12,6 +12,7 @@ jinja2 = "3.1.4"
 idna = "3.7"
 requests = "2.32.2"
 urllib3 = "2.2.2"
+certifi = "2024.7.4"
 
 
 [build-system]


### PR DESCRIPTION
- Update certifi from 2024.6.2 (vulnerable) to 2024.7.4