### PR TITLE
feat(back): #1351 multi-arch container

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -2,7 +2,7 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.actor }}
 jobs:
-  deployContainer_makesLatestAmd64:
+  deployContainer_makesAmd64:
     if: ${{ github.repository == 'fluidattacks/makes' }}
     runs-on: ubuntu-latest
     permissions:
@@ -15,8 +15,8 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainer/makesLatestAmd64"
-  deployContainer_makesLatestArm64:
+          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainer/makesAmd64"
+  deployContainer_makesArm64:
     if: ${{ github.repository == 'fluidattacks/makes' }}
     runs-on: buildjet-2vcpu-ubuntu-2204-arm
     permissions:
@@ -29,27 +29,14 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainer/makesLatestArm64"
-  deployContainer_makesPinnedAmd64:
+          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainer/makesArm64"
+  deployContainerManifest_makes:
     if: ${{ github.repository == 'fluidattacks/makes' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
       id-token: write
-    steps:
-      - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
-      - uses: docker://docker.io/nixos/nix@sha256:c3db4c484f6b1ee6c9bb8ca90307cfbeca8ef88156840911356a677eeaff4845
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainer/makesPinnedAmd64"
-  deployContainer_makesPinnedArm64:
-    if: ${{ github.repository == 'fluidattacks/makes' }}
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    permissions:
-      packages: write
-      id-token: write
+    needs: [deployContainer_makesAmd64, deployContainer_makesArm64]
     steps:
       - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
       - uses: docker://docker.io/nixos/nix@sha256:63b972c4641286c5f742d1f5b695e558cb0657502de093eb3b273460c6415ee9
@@ -57,7 +44,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainer/makesPinnedArm64"
+          args: sh -c "chown -R root:root /github/workspace && nix-env -if . && m . /deployContainerManifest/makes"
   releaseGitHub:
     if: ${{ github.repository == 'fluidattacks/makes' }}
     runs-on: ubuntu-latest

--- a/docs/src/api/builtins/deploy.md
+++ b/docs/src/api/builtins/deploy.md
@@ -314,7 +314,7 @@ Example:
             registry = "ghcr.io";
             src = outputs."/container-image";
             sign = true;
-            tag = "fluidattacks/makes/amd64:latest";
+            tag = "fluidattacks/makes:amd64";
           };
           makesArm64 = {
             attempts = 3;
@@ -325,27 +325,27 @@ Example:
             registry = "ghcr.io";
             src = outputs."/container-image";
             sign = true;
-            tag = "fluidattacks/makes/arm64:latest";
+            tag = "fluidattacks/makes:arm64";
           };
         };
       };
       deployContainerManifest = {
         makes = {
           config = {
-            image = "ghcr.io/dsalaza4/makes:latest";
+            image = "ghcr.io/fluidattacks/makes:latest";
             tags = [ "24.02" ];
             manifests = [
               {
-                image = "ghcr.io/fluidattacks/makes/arm64:latest";
+                image = "ghcr.io/fluidattacks/makes:amd64";
                 platform = {
-                  architecture = "arm64";
+                  architecture = "amd64";
                   os = "linux";
                 };
               }
               {
-                image = "ghcr.io/fluidattacks/makes/amd64:latest";
+                image = "ghcr.io/fluidattacks/makes:arm64";
                 platform = {
-                  architecture = "amd64";
+                  architecture = "arm64";
                   os = "linux";
                 };
               }

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -85,7 +85,7 @@ Example:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
-          - uses: docker://ghcr.io/fluidattacks/makes/amd64:24.02
+          - uses: docker://ghcr.io/fluidattacks/makes:24.02
             name: helloWorld
             with:
               args: sh -c "chown -R root:root /github/workspace && m . /helloWorld 1 2 3"
@@ -104,7 +104,7 @@ Example:
     ```yaml
     # .gitlab-ci.yml
     /helloWorld:
-      image: ghcr.io/fluidattacks/makes/amd64:24.02
+      image: ghcr.io/fluidattacks/makes:24.02
       script:
         - m . /helloWorld 1 2 3
     ```

--- a/makes.nix
+++ b/makes.nix
@@ -20,7 +20,7 @@
   };
   deployContainer = {
     images = {
-      makesLatestAmd64 = {
+      makesAmd64 = {
         attempts = 3;
         credentials = {
           token = "GITHUB_TOKEN";
@@ -29,9 +29,9 @@
         registry = "ghcr.io";
         src = outputs."/container-image";
         sign = true;
-        tag = "fluidattacks/makes/amd64:latest";
+        tag = "fluidattacks/makes:amd64";
       };
-      makesLatestArm64 = {
+      makesArm64 = {
         attempts = 3;
         credentials = {
           token = "GITHUB_TOKEN";
@@ -40,30 +40,37 @@
         registry = "ghcr.io";
         src = outputs."/container-image";
         sign = true;
-        tag = "fluidattacks/makes/arm64:latest";
+        tag = "fluidattacks/makes:arm64";
       };
-      makesPinnedAmd64 = {
-        attempts = 3;
-        credentials = {
-          token = "GITHUB_TOKEN";
-          user = "GITHUB_ACTOR";
-        };
-        registry = "ghcr.io";
-        src = outputs."/container-image";
-        sign = true;
-        tag = "fluidattacks/makes/amd64:24.02";
+    };
+  };
+  deployContainerManifest = {
+    makes = {
+      config = {
+        image = "ghcr.io/fluidattacks/makes:latest";
+        tags = [ "24.02" ];
+        manifests = [
+          {
+            image = "ghcr.io/fluidattacks/makes:amd64";
+            platform = {
+              architecture = "amd64";
+              os = "linux";
+            };
+          }
+          {
+            image = "ghcr.io/fluidattacks/makes:arm64";
+            platform = {
+              architecture = "arm64";
+              os = "linux";
+            };
+          }
+        ];
       };
-      makesPinnedArm64 = {
-        attempts = 3;
-        credentials = {
-          token = "GITHUB_TOKEN";
-          user = "GITHUB_ACTOR";
-        };
-        registry = "ghcr.io";
-        src = outputs."/container-image";
-        sign = true;
-        tag = "fluidattacks/makes/arm64:24.02";
+      credentials = {
+        token = "GITHUB_TOKEN";
+        user = "GITHUB_ACTOR";
       };
+      sign = true;
     };
   };
   deployTerraform = {

--- a/src/args/deploy-container/entrypoint.sh
+++ b/src/args/deploy-container/entrypoint.sh
@@ -59,11 +59,11 @@ function main {
   local tag="__argTag__"
 
   : && deploy \
-      "${attempts}" \
-      "${container_image}" \
-      "${credentials_token}" \
-      "${credentials_user}" \
-      "${tag}" \
+    "${attempts}" \
+    "${container_image}" \
+    "${credentials_token}" \
+    "${credentials_user}" \
+    "${tag}" \
     && sign \
       "${credentials_token}" \
       "${credentials_user}" \

--- a/src/evaluator/modules/pipelines/default.nix
+++ b/src/evaluator/modules/pipelines/default.nix
@@ -15,7 +15,7 @@ let
         type = lib.types.attrsOf lib.types.anything;
       };
       image = lib.mkOption {
-        default = "ghcr.io/fluidattacks/makes/amd64:24.02";
+        default = "ghcr.io/fluidattacks/makes:24.02";
         type = lib.types.str;
       };
       output = lib.mkOption { type = lib.types.str; };

--- a/test/pipelines/.gitlab-ci.yaml
+++ b/test/pipelines/.gitlab-ci.yaml
@@ -1,5 +1,5 @@
 /helloWorld__1__2__3:
-  image: ghcr.io/fluidattacks/makes/amd64:24.02
+  image: ghcr.io/fluidattacks/makes:24.02
   interruptible: true
   needs: []
   script:
@@ -8,7 +8,7 @@
     GIT_DEPTH: 3
     MAKES_GIT_DEPTH: 3
 /lintNix:
-  image: ghcr.io/fluidattacks/makes/amd64:24.02
+  image: ghcr.io/fluidattacks/makes:24.02
   interruptible: true
   needs: []
   script:


### PR DESCRIPTION
- Deploy multi-arch container on `fluidattacks/makes:latest`
- Stop using arch-based registries in favor of the root one
- Remove unnecessary CI jobs
- Update documentation on recommended makes container