### PR TITLE
fix(build): #1351 amd64 nixos image

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -39,7 +39,7 @@ jobs:
     needs: [deployContainer_makesAmd64, deployContainer_makesArm64]
     steps:
       - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
-      - uses: docker://docker.io/nixos/nix@sha256:63b972c4641286c5f742d1f5b695e558cb0657502de093eb3b273460c6415ee9
+      - uses: docker://docker.io/nixos/nix@sha256:c3db4c484f6b1ee6c9bb8ca90307cfbeca8ef88156840911356a677eeaff4845
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Use amd64 nixos image for pushing multi-arch manifest