### PR TITLE
refac(back): #1354 deprecate sandbox

### DIFF
--- a/docs/src/security/design-principles.md
+++ b/docs/src/security/design-principles.md
@@ -31,14 +31,6 @@
 
 ## Fail-Safe Defaults
 
-- By default, builds are run in a sandbox
-  that uses kernel namespaces
-  to prevent the build from accessing the network
-  and the external file system.
-
-  The user is given the option to opt-out from this behavior,
-  but this is enabled by default.
-
 - Generated files are created inside user-owned folders by default,
   which inherit the security
   that the user has previously defined for the directory.

--- a/src/cli/main/cli.py
+++ b/src/cli/main/cli.py
@@ -92,13 +92,8 @@ if AWS_BATCH_COMPAT:
     CON.out()
 
 GIT_DEPTH: int = int(environ.get("MAKES_GIT_DEPTH", "3"))
-if GIT_DEPTH != 1:
+if GIT_DEPTH != 3:
     CON.out(f"Using feature flag: MAKES_GIT_DEPTH={GIT_DEPTH}")
-
-
-K8S_COMPAT: bool = bool(environ.get("MAKES_K8S_COMPAT"))
-if K8S_COMPAT:
-    CON.out("Using feature flag: MAKES_K8S_COMPAT")
 
 
 def _if(condition: Any, *value: Any) -> List[Any]:
@@ -288,7 +283,6 @@ def _nix_build(
         *["--option", "max-jobs", "auto"],
         *["--option", "substituters", substituters],
         *["--option", "trusted-public-keys", trusted_pub_keys],
-        *["--option", "sandbox", "false" if K8S_COMPAT else "true"],
         *_if(out, "--out-link", out),
         *_if(not out, "--no-out-link"),
         *["--show-trace"],


### PR DESCRIPTION
- Deprecate sandbox option from CLI as it only works on privileged containers
or machines with multi-user nix with
a trusted user executing makes.
Ideally deciding whether or not to use sandbox
should be done by the user via nix.conf.
- Deprecate MAKES_K8S_COMPAT as it is only used for disabling sandbox,
which is now done by the user via nix.conf.
- Update design principles