### PR TITLE
feat(build): #1427 use full feature set of dockerTools functions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,7 @@ John Perez <mrjohnjairo10@gmail.com> John Perez <mrjohnjairo10@gmail.com>
 Jonathan Mesa <kidomasters@gmail.com> Jonathan Mesa <kidomasters@gmail.com>
 Julian Gomez <60365681+jgomezb11@users.noreply.github.com> Julian Gomez <60365681+jgomezb11@users.noreply.github.com>
 Julian Gomez <jgomezb11@eafit.edu.co> Julian Gomez <jgomezb11@eafit.edu.co>
+Justinodactylus <jstn@tuta.com> Justinodactylus <83211042+Justinodactylus@users.noreply.github.com>
 Karen Camargo <kjcamargo19@gmail.com> Karen Camargo <kjcamargo19@gmail.com>
 Kevin Amado <kamadorueda@gmail.com> Kevin Amado <kamadorueda@gmail.com>
 Luis Saavedra <lsaavedra@fluidattacks.com> Luis David Saavedra <40694133+ludsrill@users.noreply.github.com>

--- a/docs/src/configuration/secondary-functions/containers.md
+++ b/docs/src/configuration/secondary-functions/containers.md
@@ -23,48 +23,173 @@ Resources:
 Types:
 
 - makeContainerImage (`function { ... } -> package`):
+
+    This function accepts all parameters from the underlying [dockerTools](https://github.com/NixOS/nixpkgs/raw/refs/heads/master/doc/build-helpers/images/dockertools.section.md) functions, while providing defaults for several key attributes:
+
+    - layered (`bool`): Optional.
+        If `true`, uses the `nixpkgs.dockerTools.buildLayeredImage` function
+        to build the OCI image,
+        otherwise the `nixpkgs.dockerTools.buildImage` function is used.
+        Defaults to `true`.
+    - name (`string`): Optional.
+        Name of the created image.
+        Defaults to `"container-image"`.
+    - tag (`string`): Optional.
+        Tag of the created image.
+        Defaults to `"latest"`.
+    - created (`string`): Optional.
+        Creation date of the image in ISO-8601 format.
+        Defaults to `"1970-01-01T00:00:01Z"`.
     - layers (`listOf package`): Optional.
-        Layers of the container.
+        An alias for `contents`. Represents the layers of the container.
         Defaults to `[ ]`.
-    - maxLayers (`ints.positive`): Optional.
-        Maximum number of layers the container can have.
-        Defaults to `65`.
-    - config (`attrsOf anything`): Optional.
-        Configuration manifest as described in
-        [OCI Runtime Configuration Manifest](https://github.com/moby/docker-image-spec)
-        Defaults to `{ }`.
+
+Additionally, all other attributes from the underlying `dockerTools` functions can be passed directly.
+
+Possible attributes when `layered` is
+
+- `true`: See [here](https://github.com/NixOS/nixpkgs/blob/master/doc/build-helpers/images/dockertools.section.md#inputs-ssec-pkgs-dockertools-streamlayeredimage-inputs).
+- `false`: See [here](https://github.com/NixOS/nixpkgs/blob/master/doc/build-helpers/images/dockertools.section.md#inputs-ssec-pkgs-dockertools-buildimage-inputs).
+
+The output of this job is the path to the build OCI image in the nix store.
 
 Example:
 
-=== "makes.nix"
+=== "makes_multi_layer.nix"
 
     ```nix
+    # example for layered = true
     { inputs, makeContainerImage, makeDerivation, ... }:
     {
-      jobs."/myContainer" = makeContainerImage {
+      # Note: Some attributes are only available when layered = true.
+      jobs."/multiLayerContainer" = makeContainerImage {
+        # base image configuration
+        # to get image hash see: https://github.com/NixOS/nixpkgs/blob/master/doc/build-helpers/images/dockertools.section.md#finding-the-digest-and-hash-values-to-use-for-dockertoolspullimage
+        fromImage = inputs.nixpkgs.dockerTools.pullImage {
+          imageName = "docker.io/library/alpine"; # can be any OCI registry
+          imageDigest = "sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c";
+          hash = "sha256-BLd0y9w1FIBJO5o4Nu5Wuv9dtGhgvh+gysULwnR9lOo=";
+          finalImageTag = "3.21.3";
+        };
+
+        # image metadata
+        name = "my-application";
+        tag = "1.0.0";
+        created = "now";
+
+        # container configuration
         config = {
           Env = [
-            # Do not use this for sensitive values, it's not safe.
-            "EXAMPLE_ENV_VAR=example-value"
+            "NODE_ENV=production"
+            "LOG_LEVEL=info"
           ];
-          WorkingDir = "/working-dir";
+          WorkingDir = "/app";
+          ExposedPorts = {
+            "8080/tcp" = {};
+          };
+          Cmd = [ "/bin/sh" "-c" "node /app/server.js" ];
+          Labels = {
+            "org.opencontainers.image.source" = "https://github.com/myorg/myapp";
+            "org.opencontainers.image.description" = "My application container";
+          };
         };
+
+        # control layering behavior
+        layered = true;
+        maxLayers = 100;
+
+        # image contents/layers
         layers = [
-          inputs.nixpkgs.coreutils # ls, cat, etc
+          inputs.nixpkgs.coreutils
+          inputs.nixpkgs.nodejs_20
+
+          # custom application files
           (makeDerivation {
-            name = "custom-layer";
+            name = "application-files";
             builder = ''
-              # $out represents the final container root file system: /
-              #
-              # The following commands are equivalent in Docker to:
-              #   RUN mkdir /working-dir
-              #   RUN echo my-file-contents > /working-dir/my-file
-              #
-              mkdir -p $out/working-dir
-              echo my-file-contents > $out/working-dir/my-file
+              mkdir -p $out/app
+              cp -r ${./src}/* $out/app/
+              chmod +x $out/app/server.js
             '';
           })
         ];
+
+        # additional setup commands
+        extraCommands = ''
+          mkdir -p tmp
+          chmod 1777 tmp
+        '';
+      };
+    }
+    ```
+
+=== "makes_single_layer.nix"
+
+    ```nix
+    # example for layered = false.
+    { inputs, makeContainerImage, makeDerivation, ... }:
+    {
+      # Note: Some attributes are only available when layered = false.
+      jobs."/singleLayerContainer" = makeContainerImage {
+        # specify non-layered image
+        layered = false;
+
+        # image metadata
+        name = "static-service";
+        tag = "2.1.0";
+        created = "2026-01-19T10:30:00Z";
+
+        # container configuration
+        config = {
+          Env = [
+            "APP_ENV=production"
+            "DEBUG=false"
+          ];
+          WorkingDir = "/service";
+          User = "nobody";
+          Entrypoint = [ "/service/entrypoint.sh" ];
+          Cmd = [ "serve" "--port=8080" ];
+        };
+
+        # image contents/layers, will be merged to one layer
+        layers = [
+          inputs.nixpkgs.busybox
+          inputs.nixpkgs.nginx
+
+          # custom configuration files
+          (makeDerivation {
+            name = "service-config";
+            builder = ''
+              mkdir -p $out/service/config
+              cp ${./config}/* $out/service/config/
+
+              # Create entrypoint script
+              mkdir -p $out/service
+              cat > $out/service/entrypoint.sh << 'EOF'
+              #!/bin/sh
+              echo "Starting service..."
+              exec "$@"
+              EOF
+              chmod +x $out/service/entrypoint.sh
+            '';
+          })
+        ];
+
+        # commands to run as root during build
+        runAsRoot = ''
+          #!${inputs.nixpkgs.runtimeShell}
+          mkdir -p /var/cache/nginx
+          chmod 755 /var/cache/nginx
+        '';
+
+        # additional configuration
+        includeStorePaths = true;
+        diskSize = 1024;
+        copyToRoot = inputs.nixpkgs.buildEnv {
+          name = "image-root";
+          paths = [ inputs.nixpkgs.fakeroot ];
+          pathsToLink = [ "/bin" ];
+        };
       };
     }
     ```

--- a/src/args/make-container-image/default.nix
+++ b/src/args/make-container-image/default.nix
@@ -1,20 +1,28 @@
 # https://grahamc.com/blog/nix-and-layered-docker-images
 # https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-field-descriptions
 { __nixpkgs__, ... }:
-{ config ? null, extraCommands ? "", layered ? true, layers ? [ ]
-, maxLayers ? 65, runAsRoot ? null, }:
+{
+  layered ? true,
+  name ? "container-image",
+  tag ? "latest",
+  created ? "1970-01-01T00:00:01Z",
+  layers ? [],
+  maxLayers ? 65,
+  ...
+}@args:
 let
-  sharedAttrs = {
-    inherit config;
-    contents = layers;
-    created = "1970-01-01T00:00:01Z";
-    name = "container-image";
-    tag = "latest";
+  defaults = {
+    inherit name tag created;
   };
-in if layered then
-  __nixpkgs__.dockerTools.buildLayeredImage (sharedAttrs // {
-    inherit extraCommands;
-    inherit maxLayers;
-  })
-else
-  __nixpkgs__.dockerTools.buildImage (sharedAttrs // { inherit runAsRoot; })
+
+  # handle layers alias for contents
+  layersMapping = if args ? contents then {} else { contents = layers; };
+
+  finalAttrs = defaults // layersMapping // args;
+
+  attrs = builtins.removeAttrs finalAttrs [ "layered" "layers" ];
+in
+  if layered then
+    __nixpkgs__.dockerTools.buildLayeredImage attrs
+  else
+    __nixpkgs__.dockerTools.buildImage attrs


### PR DESCRIPTION
- Adjusts `makeContainerImage` job, to accept any `dockerTools.buildImage` and `dockerTools.buildLayeredImage` attributes
- Default values for common attributes
- Still supports both layered and non-layered image creation, controlled by 'layered' attribute
- Adds more comprehensive documentation with better examples