### PR TITLE
feat(back): #1434 add git submodules and git-lfs support for repo cloning

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -29,6 +29,7 @@ John Perez <mrjohnjairo10@gmail.com> John Perez <mrjohnjairo10@gmail.com>
 Jonathan Mesa <kidomasters@gmail.com> Jonathan Mesa <kidomasters@gmail.com>
 Julian Gomez <60365681+jgomezb11@users.noreply.github.com> Julian Gomez <60365681+jgomezb11@users.noreply.github.com>
 Julian Gomez <jgomezb11@eafit.edu.co> Julian Gomez <jgomezb11@eafit.edu.co>
+Justinodactylus <jstn@tuta.com> Justinodactylus <83211042+Justinodactylus@users.noreply.github.com>
 Karen Camargo <kjcamargo19@gmail.com> Karen Camargo <kjcamargo19@gmail.com>
 Kevin Amado <kamadorueda@gmail.com> Kevin Amado <kamadorueda@gmail.com>
 Luis Saavedra <40694133+ludsrill@users.noreply.github.com> Luis Saavedra <40694133+ludsrill@users.noreply.github.com>

--- a/src/cli/makes.nix
+++ b/src/cli/makes.nix
@@ -5,6 +5,7 @@
         __nixpkgs__.cachix
         __nixpkgs__.findutils
         __nixpkgs__.git
+        __nixpkgs__.git-lfs
         __nixpkgs__.gnutar
         __nixpkgs__.gzip
         __nixpkgs__.nixVersions.nix_2_15


### PR DESCRIPTION
- Include initialized submodule files when executing `m . <job>`
  - **Note**: The `git -C ./src ls-files --recurse-submodules --full-name --no-empty-directory` command includes ALL git tracked files, so submodule files and also modified or just added but not commited files. So the `git -C ./src diff --cached --name-only` command is not necessary anymore
- Add git-lfs to available binaries in `/src/cli/runtime` job for repos that need git lfs while initializing/checking out
- Add file existence check before copying to handle uninitialized empty submodule directories