### PR TITLE
feat(back): fluidattacks#1436 enable fallback

### DIFF
--- a/src/cli/main/cli.py
+++ b/src/cli/main/cli.py
@@ -277,6 +277,7 @@ def _nix_build(
         *["--argstr", "projectSrc", head],
         *["--argstr", "attrPaths", attr_paths],
         *["--attr", attr],
+        *["--fallback"],
         *["--option", "experimental-features", "flakes nix-command"],
         *["--option", "cores", "0"],
         *["--option", "narinfo-cache-negative-ttl", "1"],


### PR DESCRIPTION
- Enable fallback on nix-build to allow building the derivation if the output paths
through the substitutes fails